### PR TITLE
Fix: urlgroup() argument must be type list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.32"
+version = "0.1.33"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -989,6 +989,8 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
+        if not isinstance(domain_list, list):
+            raise SophosFirewallInvalidArgument("The update_urlgroup() argument `domain_list` must be of type list!")
 
         if action:
             self._validate_arg(arg_name="action",
@@ -1020,7 +1022,6 @@ class SophosFirewall:
             elif action.lower() == "replace":
                 new_domain_list.append(domain)
 
-        print(f"new_domain_list: {new_domain_list}")
         params = {"name": name, "domain_list": new_domain_list}
         resp = self.submit_template(
             "updateurlgroup.j2", template_vars=params, debug=debug


### PR DESCRIPTION
- Enforcing `domain_list` argument as a python list due to unexpected behavior if a string is passed instead of a list
- Removed print statement that was used for temporary debugging
- updated version to 0.1.33