### PR TITLE
Accommodate the use of password hash for API authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.pyc
 dist/
-nbook.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 dist/
+nbook.py

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -49,13 +49,14 @@ class SophosFirewallInvalidArgument(Exception):
 class SophosFirewall:
     """Class used for interacting with the Sophos Firewall XML API"""
 
-    def __init__(self, username, password, hostname, port, verify=True):
+    def __init__(self, username, password, hostname, port, verify=True, encrypted_password = False):
         self.username = username
         self.password = password
         self.hostname = hostname
         self.port = port
         self.url = f"https://{hostname}:{port}/webconsole/APIController"
         self.verify = verify
+        self.encrypted_password = encrypted_password
 
     # INTERNAL UTILITY CLASS METHODS
 
@@ -186,7 +187,7 @@ class SophosFirewall:
         <Request>
             <Login>
                 <Username>{self.username}</Username>
-                <Password>{self.password}</Password>
+                <Password passwordform='{"encrypt" if self.encrypted_password else "plaintext"}'>{self.password}</Password>
             </Login>
         </Request>
         """


### PR DESCRIPTION
Small change in the login function of the SophosFirewall class to be able to use a hashed password string in scripts using this wrapper instead of plaintext credentials.
This should protect somewhat against possible credential leakage, since plaintext passwords can possibly be used for interactive logins to the firewall, whereas the hashed credentials can only be used for API logins.
Since the firewall requires a whitelisted ip-address for an API-login, the attack surface of hashed API-credential misuse is a lot smaller than that of plaintext GUI-credential misuse.