### PR TITLE
Fix backup encryption

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.33"
+version = "0.1.34"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -296,6 +296,7 @@ class SophosFirewall:
         update_params: dict,
         name: str = None,
         output_format: str = "dict",
+        debug: bool = False
     ):
         """Update an existing object on the firewall.
 
@@ -304,6 +305,7 @@ class SophosFirewall:
             update_params (dict): Keys/values to be updated. Keys must match an existing XML key.
             name (str, optional): The name of the object to be updated, if applicable.
             output_format(str): Output format. Valid options are "dict" or "xml". Defaults to dict.
+            debug (bool): Displays the XML payload that was submitted 
         """
         if name:
             resp = self.get_tag_with_filter(
@@ -331,6 +333,8 @@ class SophosFirewall:
             </Set>
         </Request>
         """
+        if debug:
+            print(payload)
         resp = self._post(xmldata=payload)
         self._error_check(resp, xml_tag)
         if output_format == "xml":
@@ -1111,9 +1115,16 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-
+        updated_params = {}
+        current_params = self.get_backup()['Response']['BackupRestore']['ScheduleBackup']
+        for param in current_params:
+            if param in backup_params:
+                updated_params[param] = backup_params[param]
+            else:
+                updated_params[param] = current_params[param]
+            
         resp = self.submit_template(
-            "updatebackup.j2", template_vars=backup_params, debug=debug
+            "updatebackup.j2", template_vars=updated_params, debug=debug
         )
         return resp
 

--- a/sophosfirewall_python/templates/updatebackup.j2
+++ b/sophosfirewall_python/templates/updatebackup.j2
@@ -10,7 +10,11 @@
 			<BackupPrefix>{{ BackupPrefix | default("") }}</BackupPrefix>
 			<FTPServer>{{ FTPServer | default("") }}</FTPServer><!-- For FTP -->
 			<Username>{{ Username | default("") }}</Username><!-- For FTP -->
+			{% if "@hashform" in Password %}
+			<Password hashform="mode1">{{ Password['#text'] }}</Password>
+			{% else %}
 			<Password>{{ Password | default("") }}</Password><!-- For FTP -->
+			{% endif %}
 			<FtpPath>{{ FtpPath | default("") }}</FtpPath><!-- For FTP -->
 			<EmailAddress>{{ EmailAddress | default("") }}</EmailAddress><!--For Mail -->
 			<BackupFrequency>{{ BackupFrequency | default("") }}</BackupFrequency>
@@ -18,7 +22,11 @@
 			<Hour>{{ Hour | default("") }}</Hour>
 			<Minute>{{ Minute | default("") }}</Minute>
 			<Date>{{ Date | default("") }}</Date>
+			{% if "@hashform" in EncryptionPassword %}
+			<EncryptionPassword hashform="mode1">{{ EncryptionPassword['#text'] }}</EncryptionPassword>
+			{% else %}
 			<EncryptionPassword>{{ EncryptionPassword | default("") }}</EncryptionPassword>
+			{% endif%}
 		</ScheduleBackup>
 	</BackupRestore>
    </Set>


### PR DESCRIPTION
- Updated the `update_backup()` method so that it can properly handle encrypted vs unencrypted passwords.  When updating the password, it can be sent unencrypted.  However, when updating other parameters we must send all of the existing parameters of the backup including the existing encrypted passwords.  
- Added a debug parameter to the `update` method for easier troubleshooting