### PR TITLE
feat: add service_type argument to service create/update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.36"
+version = "0.1.37"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/templates/createservice.j2
+++ b/sophosfirewall_python/templates/createservice.j2
@@ -6,16 +6,35 @@
     <Set operation="add">
         <Services transactionid="">
             <Name>{{ name }}</Name>
-            <Type>TCPorUDP</Type>
+            <Type>{{ type }}</Type>
             <ServiceDetails>
             {% for service in service_list %}
+            {% if type == 'TCPorUDP' %}
                 <ServiceDetail>
                     <SourcePort>{{ service.get(src_port, '1:65535') }}</SourcePort>
                     <DestinationPort>{{ service.dst_port }}</DestinationPort>
                     <Protocol>{{ service.protocol }}</Protocol>
                 </ServiceDetail>
+            {% endif %}
+            {% if type == 'IP' %}
+                <ServiceDetail>
+                    <ProtocolName>{{ service.protocol }}</ProtocolName>
+                </ServiceDetail>
+            {% endif %}
+            {% if type == 'ICMP' %}
+                <ServiceDetail>
+                    <ICMPType>{{ service.icmp_type }}</ICMPType>
+                    <ICMPCode>{{ service.icmp_code }}</ICMPCode>
+                </ServiceDetail>
+            {% endif %}
+            {% if type == 'ICMPv6' %}
+                <ServiceDetail>
+                    <ICMPv6Type>{{ service.icmp_type }}</ICMPType>
+                    <ICMPv6Code>{{ service.icmp_code }}</ICMPCode>
+                </ServiceDetail>
+            {% endif %}
             {% endfor %}
-            </ServiceDetails>
+             </ServiceDetails>
         </Services>
     </Set>
 </Request>

--- a/sophosfirewall_python/templates/updateservice.j2
+++ b/sophosfirewall_python/templates/updateservice.j2
@@ -6,14 +6,33 @@
     <Set operation="update">
         <Services transactionid="">
             <Name>{{ name }}</Name>
-            <Type>TCPorUDP</Type>
+            <Type>{{ type }}</Type>
             <ServiceDetails>
             {% for service in service_list %}
+            {% if type == 'TCPorUDP' %}
                 <ServiceDetail>
                     <SourcePort>{{ service.get(src_port, '1:65535') }}</SourcePort>
                     <DestinationPort>{{ service.dst_port }}</DestinationPort>
                     <Protocol>{{ service.protocol }}</Protocol>
                 </ServiceDetail>
+            {% endif %}
+            {% if type == 'IP' %}
+                <ServiceDetail>
+                    <ProtocolName>{{ service.protocol }}</ProtocolName>
+                </ServiceDetail>
+            {% endif %}
+            {% if type == 'ICMP' %}
+                <ServiceDetail>
+                    <ICMPType>{{ service.icmp_type }}</ICMPType>
+                    <ICMPCode>{{ service.icmp_code }}</ICMPCode>
+                </ServiceDetail>
+            {% endif %}
+            {% if type == 'ICMPv6' %}
+                <ServiceDetail>
+                    <ICMPv6Type>{{ service.icmp_type }}</ICMPType>
+                    <ICMPv6Code>{{ service.icmp_code }}</ICMPCode>
+                </ServiceDetail>
+            {% endif %}
             {% endfor %}
             </ServiceDetails>
         </Services>

--- a/sophosfirewall_python/tests/functional.py
+++ b/sophosfirewall_python/tests/functional.py
@@ -230,7 +230,7 @@ def test_create_service(setup):
         expected_result["Response"]["@IS_WIFI6"] = "0"
 
     assert (
-        setup.create_service(name="FUNC_TESTSVC1", service_list=[{"dst_port": 1234, "protocol": "tcp"}])
+        setup.create_service(name="FUNC_TESTSVC1", service_type="TCPorUDP", service_list=[{"dst_port": 1234, "protocol": "tcp"}])
         == expected_result
     )
 
@@ -472,7 +472,7 @@ def test_update_service(setup):
         get_result["Response"]["@IS_WIFI6"] = "0"
 
     assert (
-        setup.update_service(name="FUNC_TESTSVC1", service_list=[{"dst_port": "2222","protocol": "TCP"}])
+        setup.update_service(name="FUNC_TESTSVC1", service_type="TCPorUDP", service_list=[{"dst_port": "2222","protocol": "TCP"}])
         == update_result
     )
 


### PR DESCRIPTION
Adds a service_type argument to `create_service()` and `update_service()` so that additional service types can be supported.  
- TCPorUDP (already supported)
- IP
- ICMP
- ICMPv6

When creating/updating IP services, it is only necessary to specify the protocol as it is shown in the UI.  The protocol number is shown in the UI, however it is not used in the API.  Similarly,  for ICMP the types and codes should be provided using their names as shown in the UI rather than the numbers.  

Examples:
```python
resp = fw.create_service(name="test_esp", service_type="IP", service_list=[{"protocol": "ESP"}])

resp
{'Response': {'@APIVersion': '2000.2',
  '@IPS_CAT_VER': '1',
  '@IS_WIFI6': '0',
  'Login': {'status': 'Authentication Successful'},
  'Services': {'@transactionid': '',
   'Status': {'@code': '200',
    '#text': 'Configuration applied successfully.'}}}}

 resp = fw.update_service(name="test_esp", service_type="IP", service_list=[{"protocol": "AH"}])

 resp
{'Response': {'@APIVersion': '2000.2',
  '@IPS_CAT_VER': '1',
  '@IS_WIFI6': '0',
  'Login': {'status': 'Authentication Successful'},
  'Services': {'@transactionid': '',
   'Status': {'@code': '200',
    '#text': 'Configuration applied successfully.'}}}}

 fw.create_service(name="test_icmp_tracert", service_type="ICMP", service_list=[{"icmp_type": "Traceroute", "icmp_code": "Any Code"}])
 
{'Response': {'@APIVersion': '2000.2',
  '@IPS_CAT_VER': '1',
  '@IS_WIFI6': '0',
  'Login': {'status': 'Authentication Successful'},
  'Services': {'@transactionid': '',
   'Status': {'@code': '200',
    '#text': 'Configuration applied successfully.'}}}}

fw.update_service(name="test_icmp_tracert", service_type="ICMP", service_list=[{"icmp_type": "Destination Unreachable", "icmp_code": "Port Unreachable"}])
{'Response': {'@APIVersion': '2000.2',
  '@IPS_CAT_VER': '1',
  '@IS_WIFI6': '0',
  'Login': {'status': 'Authentication Successful'},
  'Services': {'@transactionid': '',
   'Status': {'@code': '200',
    '#text': 'Configuration applied successfully.'}}}}
```