### PR TITLE
Code modularization update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.39"
+version = "0.1.40"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/admin.py
+++ b/sophosfirewall_python/admin.py
@@ -6,8 +6,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
+
+
 class AclRule:
     """Class for working with ACL Exception Rules."""
+
     def __init__(self, api_client):
         self.client = api_client
 
@@ -26,7 +29,7 @@ class AclRule:
                 xml_tag="LocalServiceACL", key="Name", value=name, operator=operator
             )
         return self.client.get_tag(xml_tag="LocalServiceACL")
-    
+
     def update(self, host_list, service_list, action, debug):
         """Update Local Service ACL (System > Administration > Device Access > Local service ACL exception)
 
@@ -68,8 +71,10 @@ class AclRule:
 
         return resp
 
+
 class Notification:
     """Class for working with Notification settings."""
+
     def __init__(self, api_client):
         self.client = api_client
 

--- a/sophosfirewall_python/admin.py
+++ b/sophosfirewall_python/admin.py
@@ -1,0 +1,89 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+class AclRule:
+    """Class for working with ACL Exception Rules."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name=None, operator="="):
+        """Get ACL rules
+
+        Args:
+            name (str, optional): Name of rule to retrieve. Returns all if not specified.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="LocalServiceACL", key="Name", value=name, operator=operator
+            )
+        return self.client.get_tag(xml_tag="LocalServiceACL")
+    
+    def update(self, host_list, service_list, action, debug):
+        """Update Local Service ACL (System > Administration > Device Access > Local service ACL exception)
+
+        Args:
+            host_list (list, optional): List of network or host groups. Defaults to [].
+            service_list (list, optional): List of services. Defaults to [].
+            action (str, optional): Indicate 'add' or 'remove' from list. Default is 'add'.
+            verify (bool, optional): SSL Certificate checking. Defaults to True.
+            debug (bool, optional): Enable debug mode. Defaults to False.
+        """
+        if action:
+            self.client.validate_arg(
+                arg_name="action", arg_value=action, valid_choices=["add", "remove"]
+            )
+        resp = self.get()
+
+        exist_hosts = resp["Response"]["LocalServiceACL"]["Hosts"]["Host"]
+        exist_services = resp["Response"]["LocalServiceACL"]["Services"]["Service"]
+
+        if not host_list:
+            host_list = []
+        if not service_list:
+            service_list = []
+
+        if action == "add":
+            template_vars = {
+                "host_list": exist_hosts + host_list,
+                "service_list": exist_services + service_list,
+            }
+        elif action == "remove":
+            for host in host_list:
+                exist_hosts.remove(host)
+            for service in service_list:
+                exist_services.remove(service)
+            template_vars = {"host_list": exist_hosts, "service_list": exist_services}
+        resp = self.client.submit_template(
+            "updateserviceacl.j2", template_vars=template_vars, debug=debug
+        )
+
+        return resp
+
+class Notification:
+    """Class for working with Notification settings."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name):
+        """Get notification.
+
+        Args:
+            name (str, optional): Name of notification. Returns all if not specified.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="Notification", key="Name", value=name
+            )
+        return self.client.get_tag(xml_tag="Notification")

--- a/sophosfirewall_python/api_client.py
+++ b/sophosfirewall_python/api_client.py
@@ -158,25 +158,6 @@ class APIClient:
                     raise SophosFirewallAPIError(resp_dict[key])
         return xmltodict.parse(resp.content.decode())
 
-    def login(self, output_format: str = "dict"):
-        """Test login credentials.
-
-        Args:
-            output_format(str): Output format. Valid options are "dict" or "xml". Defaults to dict.
-        """
-        payload = f"""
-        <Request>
-            <Login>
-                <Username>{self.username}</Username>
-                <Password>{self.password}</Password>
-            </Login>
-        </Request>
-        """
-        resp = self._post(xmldata=payload)
-        if output_format == "xml":
-            return resp.content.decode()
-        return xmltodict.parse(resp.content.decode())
-
     def get_tag(self, xml_tag: str, output_format: str = "dict"):
         """Execute a get for a specified XML tag.
 

--- a/sophosfirewall_python/api_client.py
+++ b/sophosfirewall_python/api_client.py
@@ -12,20 +12,26 @@ import requests
 import xmltodict
 from jinja2 import Environment, FileSystemLoader
 
+
 class SophosFirewallAPIError(Exception):
     """Error raised when an API operation fails"""
+
 
 class SophosFirewallAuthFailure(Exception):
     """Error raised when authentication to firewall fails"""
 
+
 class SophosFirewallZeroRecords(Exception):
     """Error raised when a get request returns zero records"""
+
 
 class SophosFirewallOperatorError(Exception):
     """Error raised when an invalid operator is specified"""
 
+
 class SophosFirewallInvalidArgument(Exception):
     """Error raised when an invalid argument is specified"""
+
 
 class APIClient:
     """Class for making the requests to the firewall XML API."""
@@ -37,7 +43,7 @@ class APIClient:
         self.port = port
         self.url = f"https://{hostname}:{port}/webconsole/APIController"
         self.verify = verify
-    
+
     def _dict_to_lower(self, target_dict):
         """Convert the keys of a dictionary to lower-case
 
@@ -113,6 +119,25 @@ class APIClient:
             if resp_dict["Login"]["status"] == "Authentication Failure":
                 raise SophosFirewallAuthFailure("Login failed!")
         return resp
+
+    def login(self, output_format):
+        """Test login credentials.
+
+        Args:
+            output_format(str): Output format. Valid options are "dict" or "xml". Defaults to dict.
+        """
+        payload = f"""
+        <Request>
+            <Login>
+                <Username>{self.username}</Username>
+                <Password>{self.password}</Password>
+            </Login>
+        </Request>
+        """
+        resp = self._post(xmldata=payload)
+        if output_format == "xml":
+            return resp.content.decode()
+        return xmltodict.parse(resp.content.decode())
 
     def submit_template(
         self,
@@ -303,7 +328,7 @@ class APIClient:
         if output_format == "xml":
             return resp.content.decode()
         return xmltodict.parse(resp.content.decode())
-    
+
     def validate_arg(self, arg_name, arg_value, valid_choices):
         if not arg_value in valid_choices:
             raise SophosFirewallInvalidArgument(

--- a/sophosfirewall_python/api_client.py
+++ b/sophosfirewall_python/api_client.py
@@ -1,0 +1,330 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+import os
+import re
+import requests
+import xmltodict
+from jinja2 import Environment, FileSystemLoader
+
+class SophosFirewallAPIError(Exception):
+    """Error raised when an API operation fails"""
+
+class SophosFirewallAuthFailure(Exception):
+    """Error raised when authentication to firewall fails"""
+
+class SophosFirewallZeroRecords(Exception):
+    """Error raised when a get request returns zero records"""
+
+class SophosFirewallOperatorError(Exception):
+    """Error raised when an invalid operator is specified"""
+
+class SophosFirewallInvalidArgument(Exception):
+    """Error raised when an invalid argument is specified"""
+
+class APIClient:
+    """Class for making the requests to the firewall XML API."""
+
+    def __init__(self, username, password, hostname, port, verify):
+        self.username = username
+        self.password = password
+        self.hostname = hostname
+        self.port = port
+        self.url = f"https://{hostname}:{port}/webconsole/APIController"
+        self.verify = verify
+    
+    def _dict_to_lower(self, target_dict):
+        """Convert the keys of a dictionary to lower-case
+
+        Args:
+            target_dict (dict): Dictionary to be converted
+
+        Returns:
+            dict: Dictionary with all keys converted to lower case
+        """
+        return {key.lower(): val for key, val in target_dict.items()}
+
+    def _error_check(self, api_response, xml_tag):
+        """Check for errors in the API response and raise exception if present
+
+        Args:
+            api_response (Requests.response): The response object returned from the requests module
+            xml_tag (str): The XML tag being operated on
+
+        Raises:
+            SophosFirewallZeroRecords: Error raised when there are no records matching the request parameters
+            SophosFirewallAPIError: Error raised when there is a problem with the request parameters
+        """
+        response = xmltodict.parse(api_response.content.decode())["Response"]
+        lower_response = self._dict_to_lower(response)
+        if xml_tag.lower() in lower_response:
+            resp_dict = lower_response[xml_tag.lower()]
+            if "Status" in resp_dict:
+                if (
+                    resp_dict["Status"] == "Number of records Zero."
+                    or resp_dict["Status"] == "No. of records Zero."
+                ):
+                    raise SophosFirewallZeroRecords(resp_dict["Status"])
+                if "@code" in resp_dict["Status"]:
+                    if not resp_dict["Status"]["@code"].startswith("2"):
+                        raise SophosFirewallAPIError(
+                            f"{resp_dict['Status']['@code']}: {resp_dict['Status']['#text']}"
+                        )
+        else:
+            raise SophosFirewallAPIError(
+                str(xmltodict.parse(api_response.content.decode()))
+            )
+
+    def _post(self, xmldata: str) -> requests.Response:
+        """Post XML request to the firewall returning response as a dict object
+
+        Args:
+            xmldata (str): XML payload
+            verify (bool):  SSL certificate verification. Default=True.
+
+        Returns:
+            requests.Response object
+        """
+        headers = {"Accept": "application/xml"}
+        resp = requests.post(
+            self.url,
+            headers=headers,
+            data={"reqxml": xmldata},
+            verify=self.verify,
+            timeout=30,
+        )
+
+        resp_dict = xmltodict.parse(resp.content.decode())["Response"]
+        if "Status" in resp_dict:
+            if resp_dict["Status"]["@code"] == "534":
+                # IP not allowed in API Access List
+                raise SophosFirewallAPIError(resp_dict["Status"]["#text"])
+
+            if resp_dict["Status"]["@code"] == "532":
+                # API access not enabled
+                raise SophosFirewallAPIError(resp_dict["Status"]["#text"])
+
+        if "Login" in resp_dict:
+            if resp_dict["Login"]["status"] == "Authentication Failure":
+                raise SophosFirewallAuthFailure("Login failed!")
+        return resp
+
+    def submit_template(
+        self,
+        filename: str,
+        template_vars: dict,
+        template_dir: str = None,
+        debug: bool = False,
+    ) -> dict:
+        """Submits XML payload stored as a Jinja2 file
+
+        Args:
+            filename (str): Jinja2 template filename. Place in "templates" directory or configure template_dir.
+            template_vars (dict): Dictionary of variables to inject into the template. Username and password are passed in by default.
+            template_dir (str): Directory to look for templates. Default is "./templates".
+            debug (bool, optional): Enable debug mode to display XML payload. Defaults to False.
+
+        Returns:
+            dict
+        """
+        if not template_dir:
+            template_dir = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "templates"
+            )
+        environment = Environment(
+            trim_blocks=True,
+            lstrip_blocks=True,
+            loader=FileSystemLoader(template_dir),
+            autoescape=True,
+        )
+        template = environment.get_template(filename)
+        template_vars["username"] = self.username
+        template_vars["password"] = self.password
+        payload = template.render(**template_vars)
+        if debug:
+            print(f"REQUEST: {payload}")
+        resp = self._post(xmldata=payload)
+
+        resp_dict = xmltodict.parse(resp.content.decode())["Response"]
+        success_pattern = "2[0-9][0-9]"
+        for key in resp_dict:
+            if "Status" in resp_dict[key]:
+                if not re.search(success_pattern, resp_dict[key]["Status"]["@code"]):
+                    raise SophosFirewallAPIError(resp_dict[key])
+        return xmltodict.parse(resp.content.decode())
+
+    def login(self, output_format: str = "dict"):
+        """Test login credentials.
+
+        Args:
+            output_format(str): Output format. Valid options are "dict" or "xml". Defaults to dict.
+        """
+        payload = f"""
+        <Request>
+            <Login>
+                <Username>{self.username}</Username>
+                <Password>{self.password}</Password>
+            </Login>
+        </Request>
+        """
+        resp = self._post(xmldata=payload)
+        if output_format == "xml":
+            return resp.content.decode()
+        return xmltodict.parse(resp.content.decode())
+
+    def get_tag(self, xml_tag: str, output_format: str = "dict"):
+        """Execute a get for a specified XML tag.
+
+        Args:
+            xml_tag (str): XML tag for the request
+            output_format(str): Output format. Valid options are "dict" or "xml". Defaults to dict.
+        """
+        payload = f"""
+        <Request>
+            <Login>
+                <Username>{self.username}</Username>
+                <Password>{self.password}</Password>
+            </Login>
+            <Get>
+                <{xml_tag}>
+                </{xml_tag}>
+            </Get>
+        </Request>
+        """
+        resp = self._post(xmldata=payload)
+        self._error_check(resp, xml_tag)
+        if output_format == "xml":
+            return resp.content.decode()
+        return xmltodict.parse(resp.content.decode())
+
+    def get_tag_with_filter(
+        self,
+        xml_tag: str,
+        key: str,
+        value: str,
+        operator: str = "like",
+        output_format: str = dict,
+    ):
+        """Execute a get for a specified XML tag with filter criteria.
+
+        Args:
+            xml_tag (str): XML tag for the request.
+            key (str): Search key
+            value (str): Search value
+            operator (str, optional): Operator for search (“=”,”!=”,”like”). Defaults to "like".
+            output_format(str): Output format. Valid options are "dict" or "xml". Defaults to dict.
+        """
+        valid_operators = ["=", "!=", "like"]
+        if operator not in valid_operators:
+            raise SophosFirewallOperatorError(
+                f"Invalid operator '{operator}'!  Supported operators: [ {', '.join(valid_operators)} ]"
+            )
+        payload = f"""
+        <Request>
+            <Login>
+                <Username>{self.username}</Username>
+                <Password>{self.password}</Password>
+            </Login>
+            <Get>
+                <{xml_tag}>
+                    <Filter>
+                        <key name="{key}" criteria="{operator}">{value}</key>
+                    </Filter>
+                </{xml_tag}>
+            </Get>
+        </Request>
+        """
+        resp = self._post(xmldata=payload)
+        self._error_check(resp, xml_tag)
+        if output_format == "xml":
+            return resp.content.decode()
+        return xmltodict.parse(resp.content.decode())
+
+    def remove(self, xml_tag: str, name: str, output_format: str = "dict"):
+        """Remove an object from the firewall.
+
+        Args:
+            xml_tag (str): The XML tag indicating the type of object to be removed.
+            name (str): The name of the object to be removed.
+            output_format (str): Output format. Valid options are "dict" or "xml". Defaults to dict.
+        """
+        payload = f"""
+        <Request>
+            <Login>
+                <Username>{self.username}</Username>
+                <Password>{self.password}</Password>
+            </Login>
+            <Remove>
+              <{xml_tag}>
+                <Name>{name}</Name>
+              </{xml_tag}>
+            </Remove>
+        </Request>
+        """
+        resp = self._post(xmldata=payload)
+        self._error_check(resp, xml_tag)
+        if output_format == "xml":
+            return resp.content.decode()
+        return xmltodict.parse(resp.content.decode())
+
+    def update(
+        self,
+        xml_tag: str,
+        update_params: dict,
+        name: str = None,
+        output_format: str = "dict",
+        debug: bool = False,
+    ):
+        """Update an existing object on the firewall.
+
+        Args:
+            xml_tag (str): The XML tag indicating the type of object to be updated.
+            update_params (dict): Keys/values to be updated. Keys must match an existing XML key.
+            name (str, optional): The name of the object to be updated, if applicable.
+            output_format(str): Output format. Valid options are "dict" or "xml". Defaults to dict.
+            debug (bool): Displays the XML payload that was submitted
+        """
+        if name:
+            resp = self.get_tag_with_filter(
+                xml_tag=xml_tag, key="Name", value=name, operator="="
+            )
+        else:
+            resp = self.get_tag(xml_tag=xml_tag)
+
+        for key in update_params:
+            resp["Response"][xml_tag][key] = update_params[key]
+
+        update_body = {}
+        update_body[xml_tag] = resp["Response"][xml_tag]
+        xml_update_body = xmltodict.unparse(update_body, pretty=True).lstrip(
+            '<?xml version="1.0" encoding="utf-8"?>'
+        )
+        payload = f"""
+        <Request>
+            <Login>
+                <Username>{self.username}</Username>
+                <Password>{self.password}</Password>
+            </Login>
+            <Set operation="update"> 
+                {xml_update_body}
+            </Set>
+        </Request>
+        """
+        if debug:
+            print(payload)
+        resp = self._post(xmldata=payload)
+        self._error_check(resp, xml_tag)
+        if output_format == "xml":
+            return resp.content.decode()
+        return xmltodict.parse(resp.content.decode())
+    
+    def validate_arg(self, arg_name, arg_value, valid_choices):
+        if not arg_value in valid_choices:
+            raise SophosFirewallInvalidArgument(
+                f"Invalid choice for {arg_name} argument, valid choices are {valid_choices}"
+            )

--- a/sophosfirewall_python/authen.py
+++ b/sophosfirewall_python/authen.py
@@ -6,8 +6,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
+
+
 class User:
     """Class for working with User(s)."""
+
     def __init__(self, api_client):
         self.client = api_client
 
@@ -26,7 +29,7 @@ class User:
                 xml_tag="User", key="Name", value=name, operator=operator
             )
         return self.client.get_tag(xml_tag="User")
-    
+
     def create(self, debug, **kwargs):
         """Create a User
 
@@ -60,9 +63,11 @@ class User:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        resp = self.client.submit_template("createuser.j2", template_vars=kwargs, debug=debug)
+        resp = self.client.submit_template(
+            "createuser.j2", template_vars=kwargs, debug=debug
+        )
         return resp
-    
+
     def update_user_password(self, username, new_password, debug):
         """Update user password.
 
@@ -104,8 +109,10 @@ class User:
         )
         return resp
 
+
 class AdminAuthen:
     """Class for working with Admin Authentication Settings."""
+
     def __init__(self, api_client):
         self.client = api_client
 

--- a/sophosfirewall_python/authen.py
+++ b/sophosfirewall_python/authen.py
@@ -1,0 +1,118 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+class User:
+    """Class for working with User(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name, operator="="):
+        """Get local users
+
+        Args:
+            name (str, optional): Name of user. Retrieves all users if not specified.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="User", key="Name", value=name, operator=operator
+            )
+        return self.client.get_tag(xml_tag="User")
+    
+    def create(self, debug, **kwargs):
+        """Create a User
+
+        Args:
+            debug: (bool, optional): Enable debug mode. Defaults to False.
+
+        Keyword Args:
+            user (str): Username
+            name (str): User Display Name
+            description (str): User description
+            user_password (str): User password
+            user_type (str): User Type (Administrator/User)
+            profile (str): Profile name
+            group (str): Group name
+            email (str): User email address
+            access_time_policy (str, optional): Access time policy
+            sslvpn_policy (str, optional): SSL VPN policy
+            clientless_policy (str, optional): Clientless policy
+            l2tp (str, optional): L2TP Enable/Disable
+            pptp (str, optional): PPTP Enable/Disable
+            cisco (str, optional): CISCO Enable/Disable
+            quarantine_digest (str, optional): Quarantine Digest Enable/Disable
+            mac_binding (str, optional): MAC binding Enable/Disable
+            login_restriction (str, optional): Login restriction. Default = UserGroupNode.
+            isencryptcert (str, optional): Enable/Disable. Default = Disable.
+            simultaneous_logins (str, optional): Enable/Disable simultaneous login.
+            surfingquota_policy (str, optional): Surfing quota policy. Default = Unlimited.
+            applianceaccess_schedule (str, optional): Schedule for appliance access.  Default = All The Time.
+            login_restriction (str, optional): Login restriction for appliance. Default = AnyNode.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        resp = self.client.submit_template("createuser.j2", template_vars=kwargs, debug=debug)
+        return resp
+    
+    def update_user_password(self, username, new_password, debug):
+        """Update user password.
+
+        Args:
+            username (str): Username
+            new_password (str): New password. Must meet complexity requirements.
+            debug (bool, optional): Enable debug mode. Defaults to False.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        # Get the existing user
+        resp = self.get(name=username)
+        user_params = resp["Response"]["User"]
+        user_params["Password"] = new_password
+        user_params.pop("PasswordHash")
+
+        # Update the user
+        resp = self.client.submit_template(
+            "updateuserpassword.j2", template_vars=user_params, debug=debug
+        )
+        return resp
+
+    def update_admin_password(self, current_password, new_password, debug):
+        """Update the admin password.
+
+        Args:
+            current_password (str): Current admin password.
+            new_password (str): New admin password. Must meet complexity requirements.
+            debug (bool, optional): Enable debug mode. Defaults to False.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        params = {"current_password": current_password, "new_password": new_password}
+
+        resp = self.client.submit_template(
+            "updateadminpassword.j2", template_vars=params, debug=debug
+        )
+        return resp
+
+class AdminAuthen:
+    """Class for working with Admin Authentication Settings."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self):
+        """Get admin authentication settings
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        return self.client.get_tag(xml_tag="AdminAuthentication")

--- a/sophosfirewall_python/backup.py
+++ b/sophosfirewall_python/backup.py
@@ -6,8 +6,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
+
+
 class Backup:
     """Class for working with Backup settings."""
+
     def __init__(self, api_client):
         self.client = api_client
 
@@ -25,7 +28,7 @@ class Backup:
                 xml_tag="BackupRestore", key="Name", value=name
             )
         return self.client.get_tag(xml_tag="BackupRestore")
-    
+
     def update(self, backup_params, debug):
         """Updates scheduled backup settings
 
@@ -52,9 +55,7 @@ class Backup:
             dict: XML response converted to Python dictionary
         """
         updated_params = {}
-        current_params = self.get()["Response"]["BackupRestore"][
-            "ScheduleBackup"
-        ]
+        current_params = self.get()["Response"]["BackupRestore"]["ScheduleBackup"]
         for param in current_params:
             if param in backup_params:
                 updated_params[param] = backup_params[param]

--- a/sophosfirewall_python/backup.py
+++ b/sophosfirewall_python/backup.py
@@ -1,0 +1,67 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+class Backup:
+    """Class for working with Backup settings."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name=None):
+        """Get backup details.
+
+        Args:
+            name (str, optional): Name of backup schedule. Returns all if not specified.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="BackupRestore", key="Name", value=name
+            )
+        return self.client.get_tag(xml_tag="BackupRestore")
+    
+    def update(self, backup_params, debug):
+        """Updates scheduled backup settings
+
+        Args:
+            backup_params (dict): Dict containing backup settings
+            debug (bool, optional): Enable debug mode. Defaults to False.
+
+        Keyword Args:
+            BackupMode (str): Backup mode (FTP/Mail/Local)
+            BackupPrefix (str): Backup Prefix
+            FTPServer (str, optional): FTP Server IP Address
+            Username (str, optional): FTP Server username
+            Password (str, optional): FTP Server password
+            FtpPath (str, optional): FTP Server path
+            EmailAddress (str): Email address
+            BackupFrequency (str): Never/Daily/Weekly/Monthly
+            Day (str): Day
+            Hour (str): Hour
+            Minute (str): Minute
+            Date (str): Numeric representation of month
+            EncryptionPassword (str, optional): Encryption password
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        updated_params = {}
+        current_params = self.get()["Response"]["BackupRestore"][
+            "ScheduleBackup"
+        ]
+        for param in current_params:
+            if param in backup_params:
+                updated_params[param] = backup_params[param]
+            else:
+                updated_params[param] = current_params[param]
+
+        resp = self.client.submit_template(
+            "updatebackup.j2", template_vars=updated_params, debug=debug
+        )
+        return resp

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -148,29 +148,6 @@ class SophosFirewall:
             operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
         """
         return self.ip_hostgroup.get(name, operator)
-    
-    def get_ip_network(
-        self, name: str = None, ip_address: str = None, operator: str = "="
-    ):
-        """Get IP Network object(s)
-
-        Args:
-            name (str, optional): IP object name. Returns all objects if not specified.
-            ip_address (str, optional): Query by IP Address.
-            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
-        """
-        return self.ip_network.get(name, ip_address, operator)
-    
-    def get_ip_range(
-        self, name: str = None, operator: str = "="
-    ):
-        """Get IP Range object(s)
-
-        Args:
-            name (str, optional): IP object name. Returns all objects if not specified.
-            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
-        """
-        return self.ip_range.get(name, operator)
 
     def get_fqdn_host(
         self, name: str = None, operator: str = "="
@@ -432,6 +409,29 @@ class SophosFirewall:
         """
         return self.firewall_rule.create(rule_params, debug)      
 
+
+    def create_ip_host(self, name: str,
+                       ip_address: str = None,
+                       mask: str = None,
+                       start_ip: str = None,
+                       end_ip: str = None, 
+                       host_type: str = "IP", 
+                       debug: bool = False):
+        """Create IP Host. 
+
+        Args:
+            name (str): Name of the object
+            ip_address (str): Host IP address or network in case of host_type=Network.
+            mask (str): Subnet mask in dotted decimal format (ex. 255.255.255.0). Only used with type: Network.
+            start_ip (str): Starting IP address in case of host_type=IPRange.
+            end_ip (str): Ending IP address in case of host_type=IPRange. 
+            host_type (str, optional): Type of Host. Valid options: IP, Network, IPRange.  
+            debug (bool, optional): Turn on debugging. Defaults to False.
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        return self.ip_host.create(name, ip_address, mask, start_ip, end_ip, host_type, debug)
+
     def create_ip_network(
         self,
         name: str,
@@ -451,18 +451,26 @@ class SophosFirewall:
         """
         return self.ip_network.create(name, ip_network, mask, debug)
 
-    def create_ip_host(self, name: str, ip_address: str, debug: bool = False):
-        """Create IP address object
+    def create_ip_range(
+        self,
+        name: str,
+        start_ip: str,
+        end_ip: str,
+        debug: bool = False,
+    ):
+        """Create IP range object
 
         Args:
             name (str): Name of the object
-            ip_address (str): Host IP address
+            start_ip (str): Starting IP address
+            end_ip (str): Ending IP address
             debug (bool, optional): Turn on debugging. Defaults to False.
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.ip_host.create(name, ip_address, debug)
-    
+        return self.ip_range.create(name, start_ip, end_ip, debug)
+
+
     def create_fqdn_host(self, name: str,
                          fqdn: str,
                          fqdn_group_list: list = None,
@@ -497,26 +505,6 @@ class SophosFirewall:
         """
         return self.fqdn_hostgroup.create(name, fqdn_host_list, description, debug)
         
-
-    def create_ip_range(
-        self,
-        name: str,
-        start_ip: str,
-        end_ip: str,
-        debug: bool = False,
-    ):
-        """Create IP range object
-
-        Args:
-            name (str): Name of the object
-            start_ip (str): Starting IP address
-            end_ip (str): Ending IP address
-            debug (bool, optional): Turn on debugging. Defaults to False.
-        Returns:
-            dict: XML response converted to Python dictionary
-        """
-        return self.ip_range.create(name, start_ip, end_ip, debug)
-
     def create_service(
         self,
         name: str,

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -10,13 +10,14 @@ permissions and limitations under the License.
 """
 
 import urllib3
+import xmltodict
 from sophosfirewall_python.api_client import APIClient
 from sophosfirewall_python.firewallrule import FirewallRule
 from sophosfirewall_python.host import (
     IPHost,
     IPHostGroup,
-    FQDNHost, 
-    FQDNHostGroup, 
+    FQDNHost,
+    FQDNHostGroup,
     URLGroup,
     IPNetwork,
     IPRange
@@ -67,6 +68,54 @@ class SophosFirewall:
         self.backup = Backup(self.client)
         self.report_retention = Retention(self.client)
         self.url_group = URLGroup(self.client)
+
+    def login(self, output_format: str = "dict"):
+        """Test login credentials.
+
+        Args:
+            output_format(str): Output format. Valid options are "dict" or "xml". Defaults to dict.
+        """
+        payload = f"""
+        <Request>
+            <Login>
+                <Username>{self.client.username}</Username>
+                <Password>{self.client.password}</Password>
+            </Login>
+        </Request>
+        """
+        resp = self.client._post(xmldata=payload)
+        if output_format == "xml":
+            return resp.content.decode()
+        return xmltodict.parse(resp.content.decode())
+
+    def remove(self, xml_tag: str, name: str, output_format: str = "dict"):
+        """Remove an object from the firewall.
+
+        Args:
+            xml_tag (str): The XML tag indicating the type of object to be removed.
+            name (str): The name of the object to be removed.
+            output_format (str): Output format. Valid options are "dict" or "xml". Defaults to dict.
+        """
+        return self.client.remove(xml_tag, name, output_format)
+    
+    def update(
+        self,
+        xml_tag: str,
+        update_params: dict,
+        name: str = None,
+        output_format: str = "dict",
+        debug: bool = False,
+    ):
+        """Update an existing object on the firewall.
+
+        Args:
+            xml_tag (str): The XML tag indicating the type of object to be updated.
+            update_params (dict): Keys/values to be updated. Keys must match an existing XML key.
+            name (str, optional): The name of the object to be updated, if applicable.
+            output_format(str): Output format. Valid options are "dict" or "xml". Defaults to dict.
+            debug (bool): Displays the XML payload that was submitted
+        """
+        return self.client.update(xml_tag, update_params, name, output_format, debug)
 
     # METHODS FOR OBJECT RETRIEVAL (GET)
 
@@ -446,7 +495,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary.
         """
-        self.fqdn_hostgroup.create(name, fqdn_host_list, description, debug)
+        return self.fqdn_hostgroup.create(name, fqdn_host_list, description, debug)
         
 
     def create_ip_range(
@@ -487,7 +536,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        self.service.create(name, service_type, service_list, debug)
+        return self.service.create(name, service_type, service_list, debug)
         
 
     def create_service_group(self, name: str,
@@ -523,7 +572,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        self.ip_hostgroup.create(name, host_list, description, debug)
+        return self.ip_hostgroup.create(name, host_list, description, debug)
         
 
     def create_urlgroup(self, name: str, domain_list: list, debug: bool = False):

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -10,7 +10,6 @@ permissions and limitations under the License.
 """
 
 import urllib3
-import xmltodict
 from sophosfirewall_python.api_client import APIClient
 from sophosfirewall_python.firewallrule import FirewallRule
 from sophosfirewall_python.host import (
@@ -20,7 +19,7 @@ from sophosfirewall_python.host import (
     FQDNHostGroup,
     URLGroup,
     IPNetwork,
-    IPRange
+    IPRange,
 )
 from sophosfirewall_python.service import Service, ServiceGroup
 from sophosfirewall_python.network import Interface, Vlan, Zone
@@ -34,6 +33,7 @@ from sophosfirewall_python.reports import Retention
 
 urllib3.disable_warnings()
 
+
 class SophosFirewall:
     """Class used for interacting with the Sophos Firewall XML API"""
 
@@ -43,31 +43,8 @@ class SophosFirewall:
             password=password,
             hostname=hostname,
             port=port,
-            verify=verify
+            verify=verify,
         )
-        self.firewall_rule = FirewallRule(self.client)
-        self.ip_host = IPHost(self.client)
-        self.ip_hostgroup = IPHostGroup(self.client)
-        self.fqdn_host = FQDNHost(self.client)
-        self.fqdn_hostgroup = FQDNHostGroup(self.client)
-        self.ip_network = IPNetwork(self.client)
-        self.ip_range = IPRange(self.client)
-        self.service = Service(self.client)
-        self.service_group = ServiceGroup(self.client)
-        self.interface = Interface(self.client)
-        self.vlan = Vlan(self.client)
-        self.acl_rule = AclRule(self.client)
-        self.user = User(self.client)
-        self.admin_profile = AdminProfile(self.client)
-        self.admin_auth = AdminAuthen(self.client)
-        self.zone = Zone(self.client)
-        self.ips = IPS(self.client)
-        self.syslog_server = Syslog(self.client)
-        self.notification = Notification(self.client)
-        self.notification_list = NotificationList(self.client)
-        self.backup = Backup(self.client)
-        self.report_retention = Retention(self.client)
-        self.url_group = URLGroup(self.client)
 
     def login(self, output_format: str = "dict"):
         """Test login credentials.
@@ -75,18 +52,7 @@ class SophosFirewall:
         Args:
             output_format(str): Output format. Valid options are "dict" or "xml". Defaults to dict.
         """
-        payload = f"""
-        <Request>
-            <Login>
-                <Username>{self.client.username}</Username>
-                <Password>{self.client.password}</Password>
-            </Login>
-        </Request>
-        """
-        resp = self.client._post(xmldata=payload)
-        if output_format == "xml":
-            return resp.content.decode()
-        return xmltodict.parse(resp.content.decode())
+        return self.client.login(output_format)
 
     def remove(self, xml_tag: str, name: str, output_format: str = "dict"):
         """Remove an object from the firewall.
@@ -97,7 +63,7 @@ class SophosFirewall:
             output_format (str): Output format. Valid options are "dict" or "xml". Defaults to dict.
         """
         return self.client.remove(xml_tag, name, output_format)
-    
+
     def update(
         self,
         xml_tag: str,
@@ -126,7 +92,7 @@ class SophosFirewall:
             name (str, optional): Firewall Rule name.  Returns all rules if not specified.
             operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
         """
-        return self.firewall_rule.get(name=name, operator=operator)
+        return FirewallRule(self.client).get(name=name, operator=operator)
 
     def get_ip_host(
         self, name: str = None, ip_address: str = None, operator: str = "="
@@ -138,8 +104,8 @@ class SophosFirewall:
             ip_address (str, optional): Query by IP Address.
             operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
         """
-        return self.ip_host.get(name, ip_address, operator)
-    
+        return IPHost(self.client).get(name, ip_address, operator)
+
     def get_ip_hostgroup(self, name: str = None, operator: str = "="):
         """Get IP hostgroup(s)
 
@@ -147,41 +113,34 @@ class SophosFirewall:
             name (str, optional): Name of IP host group. Returns all if not specified.
             operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
         """
-        return self.ip_hostgroup.get(name, operator)
+        return IPHostGroup(self.client).get(name, operator)
 
-    def get_fqdn_host(
-        self, name: str = None, operator: str = "="
-    ):
+    def get_fqdn_host(self, name: str = None, operator: str = "="):
         """Get FQDN Host object(s)
 
         Args:
             name (str, optional): FQDN Host name. Returns all objects if not specified.
             operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
         """
-        return self.fqdn_host.get(name, operator)
-    
-    def get_fqdn_hostgroup(
-        self, name: str = None, operator: str = "="
-    ):
+        return FQDNHost(self.client).get(name, operator)
+
+    def get_fqdn_hostgroup(self, name: str = None, operator: str = "="):
         """Get FQDN HostGroup object(s)
 
         Args:
             name (str, optional): FQDN HostGroup name. Returns all objects if not specified.
             operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
         """
-        return self.fqdn_hostgroup.get(name, operator)
+        return FQDNHostGroup(self.client).get(name, operator)
 
-    
-    def get_service_group(
-        self, name: str = None, operator: str = "="
-        ):
+    def get_service_group(self, name: str = None, operator: str = "="):
         """Get Service Group object(s)
 
         Args:
             name (str, optional): Service Group name. Returns all objects if not specified.
             operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
         """
-        return self.service_group.get(name, operator)
+        return ServiceGroup(self.client).get(name, operator)
 
     def get_interface(self, name: str = None, operator: str = "="):
         """Get Interface object(s)
@@ -190,8 +149,7 @@ class SophosFirewall:
             name (str, optional): Interface name. Returns all objects if not specified.
             operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
         """
-        return self.interface.get(name, operator)
-
+        return Interface(self.client).get(name, operator)
 
     def get_vlan(self, name: str = None, operator: str = "="):
         """Get VLAN object(s)
@@ -200,7 +158,7 @@ class SophosFirewall:
             name (str, optional): VLAN name. Returns all objects if not specified.
             operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
         """
-        return self.vlan.get(name, operator)
+        return Vlan(self.client).get(name, operator)
 
     def get_acl_rule(self, name: str = None, operator: str = "="):
         """Get ACL rules
@@ -212,8 +170,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.acl_rule.get(name, operator)
-
+        return AclRule(self.client).get(name, operator)
 
     def get_user(self, name: str = None, operator: str = "="):
         """Get local users
@@ -225,8 +182,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.user.get(name, operator)
-
+        return User(self.client).get(name, operator)
 
     def get_admin_profile(self, name: str = None, operator: str = "="):
         """Get admin profiles
@@ -238,8 +194,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.admin_profile.get(name, operator)
-
+        return AdminProfile(self.client).get(name, operator)
 
     def get_zone(self, name: str = None, operator: str = "="):
         """Get zone(s)
@@ -251,7 +206,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.zone.get(name, operator)
+        return Zone(self.client).get(name, operator)
 
     def get_admin_authen(self):
         """Get admin authentication settings
@@ -259,7 +214,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.admin_auth.get()
+        return AdminAuthen(self.client).get()
 
     def get_ips_policy(self, name: str = None):
         """Get IPS policy
@@ -270,7 +225,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.ips.get(name)
+        return IPS(self.client).get(name)
 
     def get_syslog_server(self, name: str = None):
         """Get syslog server.
@@ -281,7 +236,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.syslog_server.get(name)
+        return Syslog(self.client).get(name)
 
     def get_notification(self, name: str = None):
         """Get notification.
@@ -292,8 +247,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.notification.get(name)
-
+        return Notification(self.client).get(name)
 
     def get_notification_list(self, name: str = None):
         """Get notification list.
@@ -304,7 +258,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        self.notification_list.get(name)
+        return NotificationList(self.client).get(name)
 
     def get_backup(self, name: str = None):
         """Get backup details.
@@ -315,7 +269,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.backup.get(name)
+        return Backup(self.client).get(name)
 
     def get_reports_retention(self, name: str = None):
         """Get Reports retention period.
@@ -326,7 +280,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.report_retention.get(name)
+        return Retention(self.client).get(name)
 
     def get_admin_settings(self):
         """Get Web Admin Settings (Administration > Settings)
@@ -362,8 +316,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.url_group.get(name, operator)
-
+        return URLGroup(self.client).get(name, operator)
 
     def get_service(
         self,
@@ -383,7 +336,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.service.get(name, operator, dst_proto, dst_port)
+        return Service(self.client).get(name, operator, dst_proto, dst_port)
 
     # METHODS FOR OBJECT CREATION
 
@@ -407,30 +360,34 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.firewall_rule.create(rule_params, debug)      
+        return FirewallRule(self.client).create(rule_params, debug)
 
-
-    def create_ip_host(self, name: str,
-                       ip_address: str = None,
-                       mask: str = None,
-                       start_ip: str = None,
-                       end_ip: str = None, 
-                       host_type: str = "IP", 
-                       debug: bool = False):
-        """Create IP Host. 
+    def create_ip_host(
+        self,
+        name: str,
+        ip_address: str = None,
+        mask: str = None,
+        start_ip: str = None,
+        end_ip: str = None,
+        host_type: str = "IP",
+        debug: bool = False,
+    ):
+        """Create IP Host.
 
         Args:
             name (str): Name of the object
             ip_address (str): Host IP address or network in case of host_type=Network.
             mask (str): Subnet mask in dotted decimal format (ex. 255.255.255.0). Only used with type: Network.
             start_ip (str): Starting IP address in case of host_type=IPRange.
-            end_ip (str): Ending IP address in case of host_type=IPRange. 
-            host_type (str, optional): Type of Host. Valid options: IP, Network, IPRange.  
+            end_ip (str): Ending IP address in case of host_type=IPRange.
+            host_type (str, optional): Type of Host. Valid options: IP, Network, IPRange.
             debug (bool, optional): Turn on debugging. Defaults to False.
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.ip_host.create(name, ip_address, mask, start_ip, end_ip, host_type, debug)
+        return IPHost(self.client).create(
+            name, ip_address, mask, start_ip, end_ip, host_type, debug
+        )
 
     def create_ip_network(
         self,
@@ -449,7 +406,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.ip_network.create(name, ip_network, mask, debug)
+        return IPNetwork(self.client).create(name, ip_network, mask, debug)
 
     def create_ip_range(
         self,
@@ -468,18 +425,20 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.ip_range.create(name, start_ip, end_ip, debug)
+        return IPRange(self.client).create(name, start_ip, end_ip, debug)
 
-
-    def create_fqdn_host(self, name: str,
-                         fqdn: str,
-                         fqdn_group_list: list = None,
-                         description: str = None,
-                         debug: bool = False):
+    def create_fqdn_host(
+        self,
+        name: str,
+        fqdn: str,
+        fqdn_group_list: list = None,
+        description: str = None,
+        debug: bool = False,
+    ):
         """Create FQDN Host object.
 
         Args:
-            name (str): Name of the object. 
+            name (str): Name of the object.
             fqdn (str): FQDN string.
             fqdn_group_list (list, optional): List containing FQDN Host Group(s) to associate the FQDN Host.
             description (str): Description.
@@ -487,12 +446,17 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary.
         """
-        return self.fqdn_host.create(name, fqdn, fqdn_group_list, description, debug)
+        return FQDNHost(self.client).create(
+            name, fqdn, fqdn_group_list, description, debug
+        )
 
-    def create_fqdn_hostgroup(self, name: str,
-                         fqdn_host_list: list = None,
-                         description: str = None,
-                         debug: bool = False):
+    def create_fqdn_hostgroup(
+        self,
+        name: str,
+        fqdn_host_list: list = None,
+        description: str = None,
+        debug: bool = False,
+    ):
         """Create FQDN HostGroup object.
 
         Args:
@@ -503,8 +467,10 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary.
         """
-        return self.fqdn_hostgroup.create(name, fqdn_host_list, description, debug)
-        
+        return FQDNHostGroup(self.client).create(
+            name, fqdn_host_list, description, debug
+        )
+
     def create_service(
         self,
         name: str,
@@ -517,31 +483,33 @@ class SophosFirewall:
         Args:
             name (str): Service name.
             service_type (str): Service type. Valid values are TCPorUDP, IP, ICMP, or ICMPv6.
-            service_list(list): List of dictionaries. 
+            service_list(list): List of dictionaries.
                 For type TCPorUDP, src_port(str, optional) default=1:65535, dst_port(str), and protocol(str).
                 For type IP, protocol(str). For type ICMP and ICMPv6, icmp_type (str) and icmp_code (str).
             debug (bool, optional): Enable debug mode. Defaults to False.
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.service.create(name, service_type, service_list, debug)
-        
+        return Service(self.client).create(name, service_type, service_list, debug)
 
-    def create_service_group(self, name: str,
-                         service_list: list = None,
-                         description: str = None,
-                         debug: bool = False):
+    def create_service_group(
+        self,
+        name: str,
+        service_list: list = None,
+        description: str = None,
+        debug: bool = False,
+    ):
         """Create Service Group object.
 
         Args:
             name (str): Name of the object.
             service_list (list, optional): List containing Service(s) to associate the Services Group.
-            description (str): Description. 
+            description (str): Description.
             debug (bool, optional): Turn on debugging. Defaults to False.
         Returns:
             dict: XML response converted to Python dictionary.
         """
-        return self.service_group.create(name, service_list, description, debug)
+        return ServiceGroup(self.client).create(name, service_list, description, debug)
 
     def create_ip_hostgroup(
         self,
@@ -560,8 +528,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.ip_hostgroup.create(name, host_list, description, debug)
-        
+        return IPHostGroup(self.client).create(name, host_list, description, debug)
 
     def create_urlgroup(self, name: str, domain_list: list, debug: bool = False):
         """Create a web URL Group
@@ -574,8 +541,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.url_group.create(name, domain_list, debug)
-        
+        return URLGroup(self.client).create(name, domain_list, debug)
 
     def create_user(self, debug: bool = False, **kwargs):
         """Create a User
@@ -610,8 +576,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.user.create(debug, **kwargs)
-
+        return User(self.client).create(debug, **kwargs)
 
     def update_user_password(
         self, username: str, new_password: str, debug: bool = False
@@ -626,8 +591,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.user.update_user_password(username, new_password, debug)
-        
+        return User(self.client).update_user_password(username, new_password, debug)
 
     def update_admin_password(
         self, current_password: str, new_password: str, debug: bool = False
@@ -642,7 +606,9 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.user.update_admin_password(current_password, new_password, debug)
+        return User(self.client).update_admin_password(
+            current_password, new_password, debug
+        )
 
     def update_urlgroup(
         self, name: str, domain_list: list, action: str = "add", debug: bool = False
@@ -658,7 +624,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.url_group.update(name, domain_list, action, debug)
+        return URLGroup(self.client).update(name, domain_list, action, debug)
 
     def update_service(
         self,
@@ -673,7 +639,7 @@ class SophosFirewall:
         Args:
             name (str): Service name.
             service_type (str): Service type. Valid values are TCPorUDP, IP, ICMP, or ICMPv6.
-            service_list(list): List of dictionaries. 
+            service_list(list): List of dictionaries.
                 For type TCPorUDP, src_port(str, optional) default=1:65535, dst_port(str), and protocol(str).
                 For type IP, protocol(str). For type ICMP and ICMPv6, icmp_type (str) and icmp_code (str).
             action (str): Options are 'add', 'remove' or 'replace'. Defaults to 'add'.
@@ -682,7 +648,9 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.service.update(name, service_type, service_list, action, debug)
+        return Service(self.client).update(
+            name, service_type, service_list, action, debug
+        )
 
     def update_ip_hostgroup(
         self,
@@ -704,7 +672,9 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.ip_hostgroup.update(name, host_list, description, action, debug)
+        return IPHostGroup(self.client).update(
+            name, host_list, description, action, debug
+        )
 
     def update_fqdn_hostgroup(
         self,
@@ -726,7 +696,9 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.fqdn_hostgroup.update(name, description,fqdn_host_list, action, debug)
+        return FQDNHostGroup(self.client).update(
+            name, description, fqdn_host_list, action, debug
+        )
 
     def update_service_group(
         self,
@@ -749,7 +721,9 @@ class SophosFirewall:
             dict: XML response converted to Python dictionary
         """
         # Get the existing Host list first, if any
-        return self.service_group.update(name, service_list, description, action, debug)
+        return ServiceGroup(self.client).update(
+            name, service_list, description, action, debug
+        )
 
     def update_backup(self, backup_params: dict, debug: bool = False):
         """Updates scheduled backup settings
@@ -776,7 +750,7 @@ class SophosFirewall:
         Returns:
             dict: XML response converted to Python dictionary
         """
-        return self.backup.update(backup_params, debug)
+        return Backup(self.client).update(backup_params, debug)
 
     def update_service_acl(
         self,
@@ -794,4 +768,4 @@ class SophosFirewall:
             verify (bool, optional): SSL Certificate checking. Defaults to True.
             debug (bool, optional): Enable debug mode. Defaults to False.
         """
-        return self.acl_rule.update(host_list, service_list, action, debug)
+        return AclRule(self.client).update(host_list, service_list, action, debug)

--- a/sophosfirewall_python/firewallrule.py
+++ b/sophosfirewall_python/firewallrule.py
@@ -1,0 +1,51 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+
+class FirewallRule:
+    """Class for working with firewall rule(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+    
+    def get(self, name, operator):
+        """Get firewall rule(s)
+
+        Args:
+            name (str, optional): Firewall Rule name.  Returns all rules if not specified.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="FirewallRule", key="Name", value=name, operator=operator
+            )
+        return self.client.get_tag(xml_tag="FirewallRule")
+    
+    def create(self, rule_params, debug):
+        """Create a firewall rule
+
+        Args:
+            rule_params (dict): Configuration parmeters for the rule, see Keyword Args for supported parameters.
+
+        Keyword Args:
+            rulename(str): Name of the firewall rule
+            after_rulename(str): Name of the rule to insert this rule after
+            action(str): Accept, Drop, Reject
+            description(str): Rule description
+            log(str): Enable, Disable
+            src_zones(list): Name(s) of the source zone(s)
+            dst_zones(list): Name(s) of the destination zone(s)
+            src_networks(list): Name(s) of the source network(s)
+            dst_networks(list): Name(s) of the destination network(s)
+            service_list(list): Name(s) of service(s)
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        resp = self.client.submit_template(
+            "createfwrule.j2", template_vars=rule_params, debug=debug
+        )
+        return resp

--- a/sophosfirewall_python/firewallrule.py
+++ b/sophosfirewall_python/firewallrule.py
@@ -7,11 +7,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 permissions and limitations under the License.
 """
 
+
 class FirewallRule:
     """Class for working with firewall rule(s)."""
+
     def __init__(self, api_client):
         self.client = api_client
-    
+
     def get(self, name, operator):
         """Get firewall rule(s)
 
@@ -24,7 +26,7 @@ class FirewallRule:
                 xml_tag="FirewallRule", key="Name", value=name, operator=operator
             )
         return self.client.get_tag(xml_tag="FirewallRule")
-    
+
     def create(self, rule_params, debug):
         """Create a firewall rule
 

--- a/sophosfirewall_python/host.py
+++ b/sophosfirewall_python/host.py
@@ -35,22 +35,38 @@ class IPHost:
             )
         return self.client.get_tag(xml_tag="IPHost")
     
-    def create(self, name, ip_address, debug):
-        """Create IP address object
+    def create(self, name, ip_address, mask, start_ip, end_ip, host_type, debug):
+        """Create IP Host. 
 
         Args:
             name (str): Name of the object
-            ip_address (str): Host IP address
+            ip_address (str): Host IP address or network in case of host_type=Network.
+            mask (str): Subnet mask in dotted decimal format (ex. 255.255.255.0). Only used with type: Network.
+            start_ip (str): Starting IP address in case of host_type=IPRange.
+            end_ip (str): Ending IP address in case of host_type=IPRange. 
+            host_type (str, optional): Type of Host. Valid options: IP, Network, IPRange.  
             debug (bool, optional): Turn on debugging. Defaults to False.
         Returns:
             dict: XML response converted to Python dictionary
         """
-        Utils.validate_ip_address(ip_address)
 
-        params = {"name": name, "ip_address": ip_address}
+        if host_type == "IP":
+            Utils.validate_ip_address(ip_address)
+            params = {"name": name, "ip_address": ip_address, "host_type": host_type}
+
+        if host_type == "Network":
+            Utils.validate_ip_network(ip_address, mask)
+            params = {"name": name, "ip_address": ip_address, "mask": mask, "host_type": host_type}
+
+        if host_type == "IPRange":
+            Utils.validate_ip_address(start_ip)
+            Utils.validate_ip_address(end_ip)
+            params = {"name": name, "start_ip": start_ip, "end_ip": end_ip, "host_type": host_type}
+
         resp = self.client.submit_template(
             "createiphost.j2", template_vars=params, debug=debug
         )
+        
         return resp
 
 
@@ -425,32 +441,12 @@ class URLGroup:
         return resp
 
 class IPNetwork:
-    """Class for working with IP Network(s)."""
+    """Class for working with Host of type Network."""
     def __init__(self, api_client):
         self.client = api_client
-    
-    def get(self, name, ip_address, operator):
-        """Get Network(s).
-
-        Args:
-            name (str, optional): Get Network by name. Defaults to None.
-            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
-
-        Returns:
-            dict
-        """
-        if name:
-            return self.client.get_tag_with_filter(
-                xml_tag="Network", key="Name", operator=operator, value=name
-            )
-        if ip_address:
-            return self.client.get_tag_with_filter(
-                xml_tag="Network", key="IPAddress", operator=operator, value=ip_address
-            )
-        return self.client.get_tag(xml_tag="Network")
 
     def create(self, name, ip_network, mask, debug):
-        """Create IP network object
+        """Create IP Host of type Network.
 
         Args:
             name (str): Name of the object
@@ -469,28 +465,12 @@ class IPNetwork:
         return resp
 
 class IPRange:
-    """Class for working with IP Network(s)."""
+    """Class for working with Host of type IPRange."""
     def __init__(self, api_client):
         self.client = api_client
     
-    def get(self, name, operator):
-        """Get IP Range(s).
-
-        Args:
-            name (str, optional): Get IP Range by name. Defaults to None.
-            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
-
-        Returns:
-            dict
-        """
-        if name:
-            return self.client.get_tag_with_filter(
-                xml_tag="IPRange", key="Name", operator=operator, value=name
-            )
-        return self.client.get_tag(xml_tag="IPRange")
-    
     def create(self, name, start_ip, end_ip, debug):
-        """Create IP range object
+        """Create IP Host of type IPRange.
 
         Args:
             name (str): Name of the object

--- a/sophosfirewall_python/host.py
+++ b/sophosfirewall_python/host.py
@@ -9,8 +9,10 @@ permissions and limitations under the License.
 from sophosfirewall_python.utils import Utils
 from sophosfirewall_python.api_client import SophosFirewallInvalidArgument
 
+
 class IPHost:
     """Class for working with IP Host(s)."""
+
     def __init__(self, api_client):
         self.client = api_client
 
@@ -34,17 +36,17 @@ class IPHost:
                 operator=operator,
             )
         return self.client.get_tag(xml_tag="IPHost")
-    
+
     def create(self, name, ip_address, mask, start_ip, end_ip, host_type, debug):
-        """Create IP Host. 
+        """Create IP Host.
 
         Args:
             name (str): Name of the object
             ip_address (str): Host IP address or network in case of host_type=Network.
             mask (str): Subnet mask in dotted decimal format (ex. 255.255.255.0). Only used with type: Network.
             start_ip (str): Starting IP address in case of host_type=IPRange.
-            end_ip (str): Ending IP address in case of host_type=IPRange. 
-            host_type (str, optional): Type of Host. Valid options: IP, Network, IPRange.  
+            end_ip (str): Ending IP address in case of host_type=IPRange.
+            host_type (str, optional): Type of Host. Valid options: IP, Network, IPRange.
             debug (bool, optional): Turn on debugging. Defaults to False.
         Returns:
             dict: XML response converted to Python dictionary
@@ -56,17 +58,27 @@ class IPHost:
 
         if host_type == "Network":
             Utils.validate_ip_network(ip_address, mask)
-            params = {"name": name, "ip_address": ip_address, "mask": mask, "host_type": host_type}
+            params = {
+                "name": name,
+                "ip_address": ip_address,
+                "mask": mask,
+                "host_type": host_type,
+            }
 
         if host_type == "IPRange":
             Utils.validate_ip_address(start_ip)
             Utils.validate_ip_address(end_ip)
-            params = {"name": name, "start_ip": start_ip, "end_ip": end_ip, "host_type": host_type}
+            params = {
+                "name": name,
+                "start_ip": start_ip,
+                "end_ip": end_ip,
+                "host_type": host_type,
+            }
 
         resp = self.client.submit_template(
             "createiphost.j2", template_vars=params, debug=debug
         )
-        
+
         return resp
 
 
@@ -75,7 +87,6 @@ class IPHostGroup:
 
     def __init__(self, api_client):
         self.client = api_client
-
 
     def get(self, name, operator="="):
         """Get IP Host object(s)
@@ -93,7 +104,7 @@ class IPHostGroup:
                 operator=operator,
             )
         return self.client.get_tag(xml_tag="IPHostGroup")
-    
+
     def create(self, name, host_list, description, debug):
         """Create an IP Host Group
 
@@ -110,7 +121,7 @@ class IPHostGroup:
             "createiphostgroup.j2", template_vars=params, debug=debug
         )
         return resp
-    
+
     def update(self, name, host_list, description, action, debug):
         """Add or remove an IP Host from an IP HostGroup.
 
@@ -168,6 +179,7 @@ class IPHostGroup:
 
 class FQDNHost:
     """Class for working with FQDN Hosts."""
+
     def __init__(self, api_client):
         self.client = api_client
 
@@ -182,14 +194,14 @@ class FQDNHost:
             return self.client.get_tag_with_filter(
                 xml_tag="FQDNHost", key="Name", value=name, operator=operator
             )
-        
+
         return self.client.get_tag(xml_tag="FQDNHost")
-    
+
     def create(self, name, fqdn, fqdn_group_list, description, debug):
         """Create FQDN Host object.
 
         Args:
-            name (str): Name of the object. 
+            name (str): Name of the object.
             fqdn (str): FQDN string.
             fqdn_group_list (list, optional): List containing FQDN Host Group(s) to associate the FQDN Host.
             description (str): Description.
@@ -197,12 +209,17 @@ class FQDNHost:
         Returns:
             dict: XML response converted to Python dictionary.
         """
-        params = {"name": name, "description": description, "fqdn": fqdn, "fqdn_group_list": fqdn_group_list}
+        params = {
+            "name": name,
+            "description": description,
+            "fqdn": fqdn,
+            "fqdn_group_list": fqdn_group_list,
+        }
         resp = self.client.submit_template(
             "createfqdnhost.j2", template_vars=params, debug=debug
         )
         return resp
-    
+
     def update(self, name, fqdn_host_list, description, action, debug):
         """Add or remove a FQDN Host from an FQDN Host Group.
 
@@ -226,7 +243,10 @@ class FQDNHost:
         resp = self.get(name=name)
         if "FQDNHostList" in resp["Response"]["FQDNHostGroup"]:
             exist_list = (
-                resp.get("Response").get("FQDNHostGroup").get("FQDNHostList").get("FQDNHost")
+                resp.get("Response")
+                .get("FQDNHostGroup")
+                .get("FQDNHostList")
+                .get("FQDNHost")
             )
         else:
             exist_list = None
@@ -251,17 +271,23 @@ class FQDNHost:
         if not description:
             description = resp.get("Response").get("FQDNHostGroup").get("Description")
 
-        params = {"name": name, "description": description, "fqdn_host_list": new_host_list}
+        params = {
+            "name": name,
+            "description": description,
+            "fqdn_host_list": new_host_list,
+        }
         resp = self.client.submit_template(
             "updatefqdnhostgroup.j2", template_vars=params, debug=debug
         )
         return resp
-    
+
+
 class FQDNHostGroup:
     """Class for working with FQDN HostGroup(s)."""
+
     def __init__(self, api_client):
         self.client = api_client
-    
+
     def get(self, name, operator="="):
         """Get FQDN HostGroup object(s)
 
@@ -273,9 +299,9 @@ class FQDNHostGroup:
             return self.client.get_tag_with_filter(
                 xml_tag="FQDNHostGroup", key="Name", value=name, operator=operator
             )
-        
+
         return self.client.get_tag(xml_tag="FQDNHostGroup")
-    
+
     def create(self, name, fqdn_host_list, description, debug):
         """Create FQDN HostGroup object.
 
@@ -287,12 +313,16 @@ class FQDNHostGroup:
         Returns:
             dict: XML response converted to Python dictionary.
         """
-        params = {"name": name, "description": description, "fqdn_host_list": fqdn_host_list}
+        params = {
+            "name": name,
+            "description": description,
+            "fqdn_host_list": fqdn_host_list,
+        }
         resp = self.client.submit_template(
             "createfqdnhostgroup.j2", template_vars=params, debug=debug
         )
         return resp
-    
+
     def update(self, name, description, fqdn_host_list, action, debug):
         """Add or remove a FQDN Host from an FQDN Host Group.
 
@@ -316,7 +346,10 @@ class FQDNHostGroup:
         resp = self.get(name=name)
         if "FQDNHostList" in resp["Response"]["FQDNHostGroup"]:
             exist_list = (
-                resp.get("Response").get("FQDNHostGroup").get("FQDNHostList").get("FQDNHost")
+                resp.get("Response")
+                .get("FQDNHostGroup")
+                .get("FQDNHostList")
+                .get("FQDNHost")
             )
         else:
             exist_list = None
@@ -341,17 +374,23 @@ class FQDNHostGroup:
         if not description:
             description = resp.get("Response").get("FQDNHostGroup").get("Description")
 
-        params = {"name": name, "description": description, "fqdn_host_list": new_host_list}
+        params = {
+            "name": name,
+            "description": description,
+            "fqdn_host_list": new_host_list,
+        }
         resp = self.client.submit_template(
             "updatefqdnhostgroup.j2", template_vars=params, debug=debug
         )
         return resp
-    
+
+
 class URLGroup:
     """Class for working with URL Group(s)."""
+
     def __init__(self, api_client):
         self.client = api_client
-    
+
     def get(self, name, operator="="):
         """Get URLGroup(s)
 
@@ -367,7 +406,7 @@ class URLGroup:
                 xml_tag="WebFilterURLGroup", key="Name", operator=operator, value=name
             )
         return self.client.get_tag(xml_tag="WebFilterURLGroup")
-    
+
     def create(self, name, domain_list, debug):
         """Create a web URL Group
 
@@ -440,8 +479,10 @@ class URLGroup:
         )
         return resp
 
+
 class IPNetwork:
     """Class for working with Host of type Network."""
+
     def __init__(self, api_client):
         self.client = api_client
 
@@ -464,11 +505,13 @@ class IPNetwork:
         )
         return resp
 
+
 class IPRange:
     """Class for working with Host of type IPRange."""
+
     def __init__(self, api_client):
         self.client = api_client
-    
+
     def create(self, name, start_ip, end_ip, debug):
         """Create IP Host of type IPRange.
 

--- a/sophosfirewall_python/host.py
+++ b/sophosfirewall_python/host.py
@@ -1,0 +1,510 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+from sophosfirewall_python.utils import Utils
+from sophosfirewall_python.api_client import SophosFirewallInvalidArgument
+
+class IPHost:
+    """Class for working with IP Host(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name, ip_address, operator):
+        """Get IP Host object(s)
+
+        Args:
+            name (str, optional): IP object name. Returns all objects if not specified.
+            ip_address (str, optional): Query by IP Address.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="IPHost", key="Name", value=name, operator=operator
+            )
+        if ip_address:
+            return self.client.get_tag_with_filter(
+                xml_tag="IPHost",
+                key="IPAddress",
+                value=ip_address,
+                operator=operator,
+            )
+        return self.client.get_tag(xml_tag="IPHost")
+    
+    def create(self, name, ip_address, debug):
+        """Create IP address object
+
+        Args:
+            name (str): Name of the object
+            ip_address (str): Host IP address
+            debug (bool, optional): Turn on debugging. Defaults to False.
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        Utils.validate_ip_address(ip_address)
+
+        params = {"name": name, "ip_address": ip_address}
+        resp = self.client.submit_template(
+            "createiphost.j2", template_vars=params, debug=debug
+        )
+        return resp
+
+
+class IPHostGroup:
+    """Class for working with IP Host Group(s)."""
+
+    def __init__(self, api_client):
+        self.client = api_client
+
+
+    def get(self, name, operator="="):
+        """Get IP Host object(s)
+
+        Args:
+            name (str, optional): IP object name. Returns all objects if not specified.
+            ip_address (str, optional): Query by IP Address.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="IPHostGroup",
+                key="Name",
+                value=name,
+                operator=operator,
+            )
+        return self.client.get_tag(xml_tag="IPHostGroup")
+    
+    def create(self, name, host_list, description, debug):
+        """Create an IP Host Group
+
+        Args:
+            name (str): IP Host Group name
+            description (str): Host Group description
+            host_list (list): List of existing IP hosts to add to the group
+            debug (bool, optional): Enable debug mode. Defaults to False.
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        params = {"name": name, "description": description, "host_list": host_list}
+        resp = self.client.submit_template(
+            "createiphostgroup.j2", template_vars=params, debug=debug
+        )
+        return resp
+    
+    def update(self, name, host_list, description, action, debug):
+        """Add or remove an IP Host from an IP HostGroup.
+
+        Args:
+            name (str): IP Host Group name.
+            description (str): IP Host Group description.
+            host_list (str): List of IP Hosts to be added to or removed from the Host List.
+            action (str): Options are 'add', 'remove' or 'replace'. Specify None to disable updating Host List. Defaults to 'add'.
+            debug (bool, optional): Enable debug mode. Defaults to False.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if action:
+            self.client.validate_arg(
+                arg_name="action",
+                arg_value=action,
+                valid_choices=["add", "remove", "replace"],
+            )
+
+        resp = self.get(name=name)
+        if "HostList" in resp["Response"]["IPHostGroup"]:
+            exist_list = (
+                resp.get("Response").get("IPHostGroup").get("HostList").get("Host")
+            )
+        else:
+            exist_list = None
+
+        if action.lower() == "replace":
+            exist_list = None
+
+        new_host_list = []
+        if exist_list:
+            if isinstance(exist_list, str):
+                new_host_list.append(exist_list)
+            elif isinstance(exist_list, list):
+                new_host_list = exist_list
+        for ip_host in host_list:
+            if action:
+                if action.lower() == "add" and not ip_host in new_host_list:
+                    new_host_list.append(ip_host)
+                elif action.lower() == "remove" and ip_host in new_host_list:
+                    new_host_list.remove(ip_host)
+                elif action.lower() == "replace":
+                    new_host_list.append(ip_host)
+        if not description:
+            description = resp.get("Response").get("IPHostGroup").get("Description")
+
+        params = {"name": name, "description": description, "host_list": new_host_list}
+        resp = self.client.submit_template(
+            "updateiphostgroup.j2", template_vars=params, debug=debug
+        )
+        return resp
+
+
+class FQDNHost:
+    """Class for working with FQDN Hosts."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name, operator="="):
+        """Get FQDN Host object(s)
+
+        Args:
+            name (str, optional): FQDN Host name. Returns all objects if not specified.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="FQDNHost", key="Name", value=name, operator=operator
+            )
+        
+        return self.client.get_tag(xml_tag="FQDNHost")
+    
+    def create(self, name, fqdn, fqdn_group_list, description, debug):
+        """Create FQDN Host object.
+
+        Args:
+            name (str): Name of the object. 
+            fqdn (str): FQDN string.
+            fqdn_group_list (list, optional): List containing FQDN Host Group(s) to associate the FQDN Host.
+            description (str): Description.
+            debug (bool, optional): Turn on debugging. Defaults to False.
+        Returns:
+            dict: XML response converted to Python dictionary.
+        """
+        params = {"name": name, "description": description, "fqdn": fqdn, "fqdn_group_list": fqdn_group_list}
+        resp = self.client.submit_template(
+            "createfqdnhost.j2", template_vars=params, debug=debug
+        )
+        return resp
+    
+    def update(self, name, fqdn_host_list, description, action, debug):
+        """Add or remove a FQDN Host from an FQDN Host Group.
+
+        Args:
+            name (str): FQDN Host Group name.
+            description (str): FQDN Host Group description.
+            fqdn_host_list (str): List of FQDN Hosts to be added to or removed from the FQDN Host list.
+            action (str): Options are 'add', 'remove' or 'replace'. Specify None to disable updating FQDN Host List. Defaults to 'add'.
+            debug (bool, optional): Enable debug mode. Defaults to False.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if action:
+            self.client.validate_arg(
+                arg_name="action",
+                arg_value=action,
+                valid_choices=["add", "remove", "replace"],
+            )
+
+        resp = self.get(name=name)
+        if "FQDNHostList" in resp["Response"]["FQDNHostGroup"]:
+            exist_list = (
+                resp.get("Response").get("FQDNHostGroup").get("FQDNHostList").get("FQDNHost")
+            )
+        else:
+            exist_list = None
+
+        if action.lower() == "replace":
+            exist_list = None
+
+        new_host_list = []
+        if exist_list:
+            if isinstance(exist_list, str):
+                new_host_list.append(exist_list)
+            elif isinstance(exist_list, list):
+                new_host_list = exist_list
+        for fqdn_host in fqdn_host_list:
+            if action:
+                if action.lower() == "add" and not fqdn_host in new_host_list:
+                    new_host_list.append(fqdn_host)
+                elif action.lower() == "remove" and fqdn_host in new_host_list:
+                    new_host_list.remove(fqdn_host)
+                elif action.lower() == "replace":
+                    new_host_list.append(fqdn_host)
+        if not description:
+            description = resp.get("Response").get("FQDNHostGroup").get("Description")
+
+        params = {"name": name, "description": description, "fqdn_host_list": new_host_list}
+        resp = self.client.submit_template(
+            "updatefqdnhostgroup.j2", template_vars=params, debug=debug
+        )
+        return resp
+    
+class FQDNHostGroup:
+    """Class for working with FQDN HostGroup(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+    
+    def get(self, name, operator="="):
+        """Get FQDN HostGroup object(s)
+
+        Args:
+            name (str, optional): FQDN HostGroup name. Returns all objects if not specified.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="FQDNHostGroup", key="Name", value=name, operator=operator
+            )
+        
+        return self.client.get_tag(xml_tag="FQDNHostGroup")
+    
+    def create(self, name, fqdn_host_list, description, debug):
+        """Create FQDN HostGroup object.
+
+        Args:
+            name (str): Name of the object.
+            fqdn_host_list (list, optional): List containing FQDN Host(s) to associate the FQDN Host Group.
+            description (str): Description.
+            debug (bool, optional): Turn on debugging. Defaults to False.
+        Returns:
+            dict: XML response converted to Python dictionary.
+        """
+        params = {"name": name, "description": description, "fqdn_host_list": fqdn_host_list}
+        resp = self.client.submit_template(
+            "createfqdnhostgroup.j2", template_vars=params, debug=debug
+        )
+        return resp
+    
+    def update(self, name, description, fqdn_host_list, action, debug):
+        """Add or remove a FQDN Host from an FQDN Host Group.
+
+        Args:
+            name (str): FQDN Host Group name.
+            description (str): FQDN Host Group description.
+            fqdn_host_list (str): List of FQDN Hosts to be added to or removed from the FQDN Host list.
+            action (str): Options are 'add', 'remove' or 'replace'. Specify None to disable updating FQDN Host List. Defaults to 'add'.
+            debug (bool, optional): Enable debug mode. Defaults to False.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if action:
+            self.client.validate_arg(
+                arg_name="action",
+                arg_value=action,
+                valid_choices=["add", "remove", "replace"],
+            )
+
+        resp = self.get(name=name)
+        if "FQDNHostList" in resp["Response"]["FQDNHostGroup"]:
+            exist_list = (
+                resp.get("Response").get("FQDNHostGroup").get("FQDNHostList").get("FQDNHost")
+            )
+        else:
+            exist_list = None
+
+        if action.lower() == "replace":
+            exist_list = None
+
+        new_host_list = []
+        if exist_list:
+            if isinstance(exist_list, str):
+                new_host_list.append(exist_list)
+            elif isinstance(exist_list, list):
+                new_host_list = exist_list
+        for fqdn_host in fqdn_host_list:
+            if action:
+                if action.lower() == "add" and not fqdn_host in new_host_list:
+                    new_host_list.append(fqdn_host)
+                elif action.lower() == "remove" and fqdn_host in new_host_list:
+                    new_host_list.remove(fqdn_host)
+                elif action.lower() == "replace":
+                    new_host_list.append(fqdn_host)
+        if not description:
+            description = resp.get("Response").get("FQDNHostGroup").get("Description")
+
+        params = {"name": name, "description": description, "fqdn_host_list": new_host_list}
+        resp = self.client.submit_template(
+            "updatefqdnhostgroup.j2", template_vars=params, debug=debug
+        )
+        return resp
+    
+class URLGroup:
+    """Class for working with URL Group(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+    
+    def get(self, name, operator="="):
+        """Get URLGroup(s)
+
+        Args:
+            name (str, optional): Get URLGroup by name. Defaults to None.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+
+        Returns:
+            dict
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="WebFilterURLGroup", key="Name", operator=operator, value=name
+            )
+        return self.client.get_tag(xml_tag="WebFilterURLGroup")
+    
+    def create(self, name, domain_list, debug):
+        """Create a web URL Group
+
+        Args:
+            name (str): URL Group name.
+            domain_list (list): List of domains to added/removed/replaced.
+            debug (bool, optional): Enable debug mode. Defaults to False.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        params = {"name": name, "domain_list": domain_list}
+        resp = self.client.submit_template(
+            "createurlgroup.j2", template_vars=params, debug=debug
+        )
+        return resp
+
+    def update(self, name, domain_list, action, debug):
+        """Add or remove a specified domain to/from a web URL Group
+
+        Args:
+            name (str): URL Group name.
+            domain_list (list): List of domains to added/removed/replaced.
+            action (str): Options are 'add', 'remove' or 'replace'. Defaults to 'add'.
+            debug (bool, optional): Enable debug mode. Defaults to False.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if not isinstance(domain_list, list):
+            raise SophosFirewallInvalidArgument(
+                "The update_urlgroup() argument `domain_list` must be of type list!"
+            )
+
+        if action:
+            self.client.validate_arg(
+                arg_name="action",
+                arg_value=action,
+                valid_choices=["add", "remove", "replace"],
+            )
+
+        # Get the existing URL list first, if any
+        resp = self.get(name=name)
+        if "URLlist" in resp["Response"]["WebFilterURLGroup"]:
+            exist_list = (
+                resp.get("Response").get("WebFilterURLGroup").get("URLlist").get("URL")
+            )
+        else:
+            exist_list = None
+        if action == "replace":
+            exist_list = None
+        new_domain_list = []
+        if exist_list:
+            if isinstance(exist_list, str):
+                new_domain_list.append(exist_list)
+            elif isinstance(exist_list, list):
+                for domain in exist_list:
+                    new_domain_list.append(domain)
+        for domain in domain_list:
+            if action.lower() == "add" and domain not in new_domain_list:
+                new_domain_list.append(domain)
+            elif action.lower() == "remove" and domain in new_domain_list:
+                new_domain_list.remove(domain)
+            elif action.lower() == "replace":
+                new_domain_list.append(domain)
+
+        params = {"name": name, "domain_list": new_domain_list}
+        resp = self.client.submit_template(
+            "updateurlgroup.j2", template_vars=params, debug=debug
+        )
+        return resp
+
+class IPNetwork:
+    """Class for working with IP Network(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+    
+    def get(self, name, ip_address, operator):
+        """Get Network(s).
+
+        Args:
+            name (str, optional): Get Network by name. Defaults to None.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+
+        Returns:
+            dict
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="Network", key="Name", operator=operator, value=name
+            )
+        if ip_address:
+            return self.client.get_tag_with_filter(
+                xml_tag="Network", key="IPAddress", operator=operator, value=ip_address
+            )
+        return self.client.get_tag(xml_tag="Network")
+
+    def create(self, name, ip_network, mask, debug):
+        """Create IP network object
+
+        Args:
+            name (str): Name of the object
+            ip_network (str): IP network address
+            mask (str): Subnet mask in dotted decimal format (ex. 255.255.255.0)
+            debug (bool, optional): Turn on debugging. Defaults to False.
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        Utils.validate_ip_network(ip_network, mask)
+
+        params = {"name": name, "ip_network": ip_network, "mask": mask}
+        resp = self.client.submit_template(
+            "createipnetwork.j2", template_vars=params, debug=debug
+        )
+        return resp
+
+class IPRange:
+    """Class for working with IP Network(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+    
+    def get(self, name, operator):
+        """Get IP Range(s).
+
+        Args:
+            name (str, optional): Get IP Range by name. Defaults to None.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+
+        Returns:
+            dict
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="IPRange", key="Name", operator=operator, value=name
+            )
+        return self.client.get_tag(xml_tag="IPRange")
+    
+    def create(self, name, start_ip, end_ip, debug):
+        """Create IP range object
+
+        Args:
+            name (str): Name of the object
+            start_ip (str): Starting IP address
+            end_ip (str): Ending IP address
+            debug (bool, optional): Turn on debugging. Defaults to False.
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        Utils.validate_ip_address(start_ip)
+        Utils.validate_ip_address(end_ip)
+
+        params = {"name": name, "start_ip": start_ip, "end_ip": end_ip}
+        resp = self.client.submit_template(
+            "createiprange.j2", template_vars=params, debug=debug
+        )
+        return resp

--- a/sophosfirewall_python/ips.py
+++ b/sophosfirewall_python/ips.py
@@ -7,8 +7,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 permissions and limitations under the License.
 """
 
+
 class IPS:
     """Class for working with IPS Policies."""
+
     def __init__(self, api_client):
         self.client = api_client
 
@@ -22,5 +24,7 @@ class IPS:
             dict: XML response converted to Python dictionary
         """
         if name:
-            return self.client.get_tag_with_filter(xml_tag="IPSPolicy", key="Name", value=name)
+            return self.client.get_tag_with_filter(
+                xml_tag="IPSPolicy", key="Name", value=name
+            )
         return self.client.get_tag(xml_tag="IPSPolicy")

--- a/sophosfirewall_python/ips.py
+++ b/sophosfirewall_python/ips.py
@@ -1,0 +1,26 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+
+class IPS:
+    """Class for working with IPS Policies."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name):
+        """Get IPS policy
+
+        Args:
+            name (str, optional): Name of a policy to filter on. Returns all if not specified.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if name:
+            return self.client.get_tag_with_filter(xml_tag="IPSPolicy", key="Name", value=name)
+        return self.client.get_tag(xml_tag="IPSPolicy")

--- a/sophosfirewall_python/network.py
+++ b/sophosfirewall_python/network.py
@@ -1,0 +1,65 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+
+class Interface:
+    """Class for working with Interface(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name, operator):
+        """Get Interface object(s)
+
+        Args:
+            name (str, optional): Interface name. Returns all objects if not specified.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="Interface", key="Name", value=name, operator=operator
+            )
+        return self.client.get_tag(xml_tag="Interface")
+    
+class Vlan:
+    """Class for working with Vlan(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name, operator):
+        """Get VLAN object(s)
+
+        Args:
+            name (str, optional): VLAN name. Returns all objects if not specified.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="VLAN", key="Name", value=name, operator=operator
+            )
+        return self.client.get_tag(xml_tag="VLAN")
+    
+class Zone:
+    """Class for working with Zone(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name, operator):
+        """Get zone(s)
+
+        Args:
+            name (str, optional): Name of zone to query. Returns all if not specified.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="Zone", key="Name", value=name, operator=operator
+            )
+        return self.client.get_tag(xml_tag="Zone")

--- a/sophosfirewall_python/network.py
+++ b/sophosfirewall_python/network.py
@@ -7,8 +7,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 permissions and limitations under the License.
 """
 
+
 class Interface:
     """Class for working with Interface(s)."""
+
     def __init__(self, api_client):
         self.client = api_client
 
@@ -24,9 +26,11 @@ class Interface:
                 xml_tag="Interface", key="Name", value=name, operator=operator
             )
         return self.client.get_tag(xml_tag="Interface")
-    
+
+
 class Vlan:
     """Class for working with Vlan(s)."""
+
     def __init__(self, api_client):
         self.client = api_client
 
@@ -42,9 +46,11 @@ class Vlan:
                 xml_tag="VLAN", key="Name", value=name, operator=operator
             )
         return self.client.get_tag(xml_tag="VLAN")
-    
+
+
 class Zone:
     """Class for working with Zone(s)."""
+
     def __init__(self, api_client):
         self.client = api_client
 

--- a/sophosfirewall_python/profile.py
+++ b/sophosfirewall_python/profile.py
@@ -6,8 +6,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
+
+
 class AdminProfile:
     """Class for working with Administration Profile(s)."""
+
     def __init__(self, api_client):
         self.client = api_client
 

--- a/sophosfirewall_python/profile.py
+++ b/sophosfirewall_python/profile.py
@@ -1,0 +1,31 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+class AdminProfile:
+    """Class for working with Administration Profile(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name, operator):
+        """Get admin profiles
+
+        Args:
+            name (str, optional): Name of profile. Returns all if not specified.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="AdministrationProfile",
+                key="Name",
+                value=name,
+                operator=operator,
+            )
+        return self.client.get_tag(xml_tag="AdministrationProfile")

--- a/sophosfirewall_python/reports.py
+++ b/sophosfirewall_python/reports.py
@@ -1,0 +1,28 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+
+class Retention:
+    """Class for working with Report Retention settings."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name):
+        """Get Reports retention period.
+
+        Args:
+            name (str, optional): Name of backup schedule. Returns all if not specified.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="DataManagement", key="Name", value=name
+            )
+        return self.client.get_tag(xml_tag="DataManagement")

--- a/sophosfirewall_python/reports.py
+++ b/sophosfirewall_python/reports.py
@@ -7,8 +7,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 permissions and limitations under the License.
 """
 
+
 class Retention:
     """Class for working with Report Retention settings."""
+
     def __init__(self, api_client):
         self.client = api_client
 

--- a/sophosfirewall_python/service.py
+++ b/sophosfirewall_python/service.py
@@ -1,0 +1,287 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+from sophosfirewall_python.api_client import SophosFirewallInvalidArgument
+
+class Service:
+    """Class for working with Service(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+        
+    def get(self, name, operator="=", dst_proto=None, dst_port=None):
+        """Get Service(s)
+
+        Args:
+            name (str, optional): Get Service by name. Defaults to None.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+            dst_proto(str, optional): Specify TCP or UDP
+            dst_port(str, optional): Specify dest TCP or UDP port. Use : to specify ranges (ex. 67:68)
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="Services", key="Name", value=name, operator=operator
+            )
+        if dst_proto and dst_port:
+            resp = self.client.get_tag(xml_tag="Services")
+            svc_list = resp["Response"]["Services"].copy()
+            for svc in svc_list:
+                matched = False
+                if isinstance(svc["ServiceDetails"]["ServiceDetail"], dict):
+                    port = svc["ServiceDetails"]["ServiceDetail"].get("DestinationPort")
+                    if "Protocol" in svc["ServiceDetails"]["ServiceDetail"]:
+                        proto = svc["ServiceDetails"]["ServiceDetail"]["Protocol"]
+                    if "ProtocolName" in svc["ServiceDetails"]["ServiceDetail"]:
+                        proto = svc["ServiceDetails"]["ServiceDetail"]["ProtocolName"]
+                    if proto == dst_proto.upper() and port == dst_port:
+                        matched = True
+                elif isinstance(svc["ServiceDetails"]["ServiceDetail"], list):
+                    for subsvc in svc["ServiceDetails"]["ServiceDetail"]:
+                        port = subsvc.get("DestinationPort")
+                        if "Protocol" in subsvc:
+                            proto = subsvc["Protocol"]
+                        if "ProtocolName" in subsvc:
+                            proto = subsvc["ProtocolName"]
+                        if proto == dst_proto.upper() and port == dst_port:
+                            matched = True
+                if not matched:
+                    resp["Response"]["Services"].remove(svc)
+            return resp
+        return self.client.get_tag(xml_tag="Services")
+    
+    def create(self, name, service_type, service_list, debug):
+        """Create a TCP or UDP service
+
+        Args:
+            name (str): Service name.
+            service_type (str): Service type. Valid values are TCPorUDP, IP, ICMP, or ICMPv6.
+            service_list(list): List of dictionaries. 
+                For type TCPorUDP, src_port(str, optional) default=1:65535, dst_port(str), and protocol(str).
+                For type IP, protocol(str). For type ICMP and ICMPv6, icmp_type (str) and icmp_code (str).
+            debug (bool, optional): Enable debug mode. Defaults to False.
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        params = {"name": name, "service_list": service_list, "type": service_type}
+        resp = self.client.submit_template(
+            "createservice.j2", template_vars=params, debug=debug
+        )
+        return resp
+    
+    def update(self, name, service_type, service_list, action, debug):
+        """Add or remove a service entry to/from a service
+
+        Args:
+            name (str): Service name.
+            service_type (str): Service type. Valid values are TCPorUDP, IP, ICMP, or ICMPv6.
+            service_list(list): List of dictionaries. 
+                For type TCPorUDP, src_port(str, optional) default=1:65535, dst_port(str), and protocol(str).
+                For type IP, protocol(str). For type ICMP and ICMPv6, icmp_type (str) and icmp_code (str).
+            action (str): Options are 'add', 'remove' or 'replace'. Defaults to 'add'.
+            debug (bool, optional): Enable debug mode. Defaults to False.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if not isinstance(service_list, list):
+            raise SophosFirewallInvalidArgument(
+                "The update_service() argument `service_list` must be of type list!"
+            )
+
+        if action:
+            self.client.validate_arg(
+                arg_name="action",
+                arg_value=action,
+                valid_choices=["add", "remove", "replace"],
+            )
+
+        # Get the existing Service list first
+        resp = self.get(name=name)
+        if "ServiceDetail" in resp["Response"]["Services"]["ServiceDetails"]:
+            exist_list = (
+                resp.get("Response")
+                .get("Services")
+                .get("ServiceDetails")
+                .get("ServiceDetail")
+            )
+        else:
+            exist_list = None
+
+        # Add src_port to input if not present
+        for service in service_list:
+            if not "src_port" in service:
+                service["src_port"] = "1:65535"
+        if action == "replace":
+            exist_list = None
+        new_service_list = []
+        if exist_list:
+            if isinstance(exist_list, dict):
+                if service_type == "TCPorUDP":
+                    new_service_list.append(
+                        {
+                            "src_port": exist_list["SourcePort"],
+                            "dst_port": exist_list["DestinationPort"],
+                            "protocol": exist_list["Protocol"],
+                        }
+                    )
+                if service_type == "IP":
+                    new_service_list.append(
+                        {
+                            "protocol": exist_list["ProtocolName"]
+                        }
+                    )
+                if service_type == "ICMP":
+                    new_service_list.append(
+                        {
+                            "icmp_type": exist_list["ICMPType"],
+                            "icmp_code": exist_list["ICMPCode"]
+                        }
+                    )
+                if service_type == "ICMPv6":
+                    new_service_list.append(
+                        {
+                            "icmp_type": exist_list["ICMPv6Type"],
+                            "icmp_code": exist_list["ICMPv6Code"]
+                        }
+                    )
+            elif isinstance(exist_list, list):
+                for service in exist_list:
+                    if service_type == "TCPorUDP":
+                        new_service_list.append(
+                            {
+                                "src_port": service["SourcePort"],
+                                "dst_port": service["DestinationPort"],
+                                "protocol": service["Protocol"],
+                            }
+                        )
+                    if service_type == "IP":
+                        new_service_list.append(
+                            {
+                                "protocol": service["ProtocolName"]
+                            }
+                        )
+                    if service_type == "ICMP":
+                        new_service_list.append(
+                            {
+                                "icmp_type": service["ICMPType"],
+                                "icmp_code": service["ICMPCode"]
+                            }
+                        )
+                    if service_type == "ICMPv6":
+                        new_service_list.append(
+                            {
+                                "icmp_type": service["ICMPv6Type"],
+                                "icmp_code": service["ICMPv6Code"]
+                            }
+                        )
+        for service in service_list:
+            if action.lower() == "add" and service not in new_service_list:
+                new_service_list.append(service)
+            elif action.lower() == "remove" and service in new_service_list:
+                new_service_list.remove(service)
+            elif action.lower() == "replace":
+                new_service_list.append(service)
+
+        params = {"name": name, "service_list": new_service_list, "type": service_type}
+        resp = self.client.submit_template(
+            "updateservice.j2", template_vars=params, debug=debug
+        )
+        return resp
+
+class ServiceGroup:
+    """Class for working with Service Group(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def get(self, name, operator="="):
+        """Get Service Group object(s)
+
+        Args:
+            name (str, optional): Service Group name. Returns all objects if not specified.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="ServiceGroup", key="Name", value=name, operator=operator
+            )
+        
+        return self.client.get_tag(xml_tag="ServiceGroup")
+    
+    def create(self, name, service_list, description, debug):
+        """Create Service Group object.
+
+        Args:
+            name (str): Name of the object.
+            service_list (list, optional): List containing Service(s) to associate the Services Group.
+            description (str): Description. 
+            debug (bool, optional): Turn on debugging. Defaults to False.
+        Returns:
+            dict: XML response converted to Python dictionary.
+        """
+        params = {"name": name, "description": description, "service_list": service_list}
+        resp = self.client.submit_template(
+            "createservicegroup.j2", template_vars=params, debug=debug
+        )
+        return resp
+    
+    def update(self, name, service_list, description, action, debug):
+        """Add or remove a Service from an Service Group.
+
+        Args:
+            name (str): Service Group name.
+            description (str): Service Group description.
+            service_list (str): List of Service(s) to be added to or removed from the Service Group.
+            action (str): Options are 'add', 'remove' or 'replace'. Specify None to disable updating Service Group List. Defaults to 'add'.
+            debug (bool, optional): Enable debug mode. Defaults to False.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if action:
+            self.client.validate_arg(
+                arg_name="action",
+                arg_value=action,
+                valid_choices=["add", "remove", "replace"],
+            )
+
+        resp = self.get(name=name)
+        if "ServiceList" in resp["Response"]["ServiceGroup"]:
+            exist_list = (
+                resp.get("Response").get("ServiceGroup").get("ServiceList").get("Service")
+            )
+        else:
+            exist_list = None
+
+        if action.lower() == "replace":
+            exist_list = None
+
+        new_service_list = []
+        if exist_list:
+            if isinstance(exist_list, str):
+                new_service_list.append(exist_list)
+            elif isinstance(exist_list, list):
+                new_service_list = exist_list
+        for service_name in service_list:
+            if action:
+                if action.lower() == "add" and not service_name in new_service_list:
+                    new_service_list.append(service_name)
+                elif action.lower() == "remove" and service_name in new_service_list:
+                    new_service_list.remove(service_name)
+                elif action.lower() == "replace":
+                    new_service_list.append(service_name)
+        if not description:
+            description = resp.get("Response").get("ServiceGroup").get("Description")
+
+        params = {"name": name, "description": description, "service_list": new_service_list}
+        resp = self.client.submit_template(
+            "updateservicegroup.j2", template_vars=params, debug=debug
+        )
+        return resp
+

--- a/sophosfirewall_python/service.py
+++ b/sophosfirewall_python/service.py
@@ -8,11 +8,13 @@ permissions and limitations under the License.
 """
 from sophosfirewall_python.api_client import SophosFirewallInvalidArgument
 
+
 class Service:
     """Class for working with Service(s)."""
+
     def __init__(self, api_client):
         self.client = api_client
-        
+
     def get(self, name, operator="=", dst_proto=None, dst_port=None):
         """Get Service(s)
 
@@ -55,14 +57,14 @@ class Service:
                     resp["Response"]["Services"].remove(svc)
             return resp
         return self.client.get_tag(xml_tag="Services")
-    
+
     def create(self, name, service_type, service_list, debug):
         """Create a TCP or UDP service
 
         Args:
             name (str): Service name.
             service_type (str): Service type. Valid values are TCPorUDP, IP, ICMP, or ICMPv6.
-            service_list(list): List of dictionaries. 
+            service_list(list): List of dictionaries.
                 For type TCPorUDP, src_port(str, optional) default=1:65535, dst_port(str), and protocol(str).
                 For type IP, protocol(str). For type ICMP and ICMPv6, icmp_type (str) and icmp_code (str).
             debug (bool, optional): Enable debug mode. Defaults to False.
@@ -74,14 +76,14 @@ class Service:
             "createservice.j2", template_vars=params, debug=debug
         )
         return resp
-    
+
     def update(self, name, service_type, service_list, action, debug):
         """Add or remove a service entry to/from a service
 
         Args:
             name (str): Service name.
             service_type (str): Service type. Valid values are TCPorUDP, IP, ICMP, or ICMPv6.
-            service_list(list): List of dictionaries. 
+            service_list(list): List of dictionaries.
                 For type TCPorUDP, src_port(str, optional) default=1:65535, dst_port(str), and protocol(str).
                 For type IP, protocol(str). For type ICMP and ICMPv6, icmp_type (str) and icmp_code (str).
             action (str): Options are 'add', 'remove' or 'replace'. Defaults to 'add'.
@@ -132,23 +134,19 @@ class Service:
                         }
                     )
                 if service_type == "IP":
-                    new_service_list.append(
-                        {
-                            "protocol": exist_list["ProtocolName"]
-                        }
-                    )
+                    new_service_list.append({"protocol": exist_list["ProtocolName"]})
                 if service_type == "ICMP":
                     new_service_list.append(
                         {
                             "icmp_type": exist_list["ICMPType"],
-                            "icmp_code": exist_list["ICMPCode"]
+                            "icmp_code": exist_list["ICMPCode"],
                         }
                     )
                 if service_type == "ICMPv6":
                     new_service_list.append(
                         {
                             "icmp_type": exist_list["ICMPv6Type"],
-                            "icmp_code": exist_list["ICMPv6Code"]
+                            "icmp_code": exist_list["ICMPv6Code"],
                         }
                     )
             elif isinstance(exist_list, list):
@@ -162,23 +160,19 @@ class Service:
                             }
                         )
                     if service_type == "IP":
-                        new_service_list.append(
-                            {
-                                "protocol": service["ProtocolName"]
-                            }
-                        )
+                        new_service_list.append({"protocol": service["ProtocolName"]})
                     if service_type == "ICMP":
                         new_service_list.append(
                             {
                                 "icmp_type": service["ICMPType"],
-                                "icmp_code": service["ICMPCode"]
+                                "icmp_code": service["ICMPCode"],
                             }
                         )
                     if service_type == "ICMPv6":
                         new_service_list.append(
                             {
                                 "icmp_type": service["ICMPv6Type"],
-                                "icmp_code": service["ICMPv6Code"]
+                                "icmp_code": service["ICMPv6Code"],
                             }
                         )
         for service in service_list:
@@ -195,8 +189,10 @@ class Service:
         )
         return resp
 
+
 class ServiceGroup:
     """Class for working with Service Group(s)."""
+
     def __init__(self, api_client):
         self.client = api_client
 
@@ -211,26 +207,30 @@ class ServiceGroup:
             return self.client.get_tag_with_filter(
                 xml_tag="ServiceGroup", key="Name", value=name, operator=operator
             )
-        
+
         return self.client.get_tag(xml_tag="ServiceGroup")
-    
+
     def create(self, name, service_list, description, debug):
         """Create Service Group object.
 
         Args:
             name (str): Name of the object.
             service_list (list, optional): List containing Service(s) to associate the Services Group.
-            description (str): Description. 
+            description (str): Description.
             debug (bool, optional): Turn on debugging. Defaults to False.
         Returns:
             dict: XML response converted to Python dictionary.
         """
-        params = {"name": name, "description": description, "service_list": service_list}
+        params = {
+            "name": name,
+            "description": description,
+            "service_list": service_list,
+        }
         resp = self.client.submit_template(
             "createservicegroup.j2", template_vars=params, debug=debug
         )
         return resp
-    
+
     def update(self, name, service_list, description, action, debug):
         """Add or remove a Service from an Service Group.
 
@@ -254,7 +254,10 @@ class ServiceGroup:
         resp = self.get(name=name)
         if "ServiceList" in resp["Response"]["ServiceGroup"]:
             exist_list = (
-                resp.get("Response").get("ServiceGroup").get("ServiceList").get("Service")
+                resp.get("Response")
+                .get("ServiceGroup")
+                .get("ServiceList")
+                .get("Service")
             )
         else:
             exist_list = None
@@ -279,9 +282,12 @@ class ServiceGroup:
         if not description:
             description = resp.get("Response").get("ServiceGroup").get("Description")
 
-        params = {"name": name, "description": description, "service_list": new_service_list}
+        params = {
+            "name": name,
+            "description": description,
+            "service_list": new_service_list,
+        }
         resp = self.client.submit_template(
             "updateservicegroup.j2", template_vars=params, debug=debug
         )
         return resp
-

--- a/sophosfirewall_python/system.py
+++ b/sophosfirewall_python/system.py
@@ -7,11 +7,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 permissions and limitations under the License.
 """
 
+
 class Syslog:
     """Class for working with Syslog Server(s)."""
+
     def __init__(self, api_client):
         self.client = api_client
-    
+
     def get(self, name):
         """Get syslog server.
 
@@ -27,11 +29,13 @@ class Syslog:
             )
         return self.client.get_tag(xml_tag="SyslogServers")
 
+
 class NotificationList:
     """Class for working with Notification List settings."""
+
     def __init__(self, api_client):
         self.client = api_client
-    
+
     def get(self, name):
         """Get notification list.
 

--- a/sophosfirewall_python/system.py
+++ b/sophosfirewall_python/system.py
@@ -1,0 +1,48 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+
+class Syslog:
+    """Class for working with Syslog Server(s)."""
+    def __init__(self, api_client):
+        self.client = api_client
+    
+    def get(self, name):
+        """Get syslog server.
+
+        Args:
+            name (str, optional): Name of syslog server. Returns all if not specified.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="SyslogServers", key="Name", value=name
+            )
+        return self.client.get_tag(xml_tag="SyslogServers")
+
+class NotificationList:
+    """Class for working with Notification List settings."""
+    def __init__(self, api_client):
+        self.client = api_client
+    
+    def get(self, name):
+        """Get notification list.
+
+        Args:
+            name (str, optional): Name of notification list. Returns all if not specified.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        if name:
+            return self.client.get_tag_with_filter(
+                xml_tag="NotificationList", key="Name", value=name
+            )
+        return self.client.get_tag(xml_tag="NotificationList")

--- a/sophosfirewall_python/templates/createiphost.j2
+++ b/sophosfirewall_python/templates/createiphost.j2
@@ -7,8 +7,20 @@
     <IPHost transactionid="">
         <Name>{{ name }}</Name>
         <IPFamily>IPv4</IPFamily>
+        {% if host_type == 'IP'%}
         <HostType>IP</HostType>
         <IPAddress>{{ ip_address }}</IPAddress>
+        {% endif %}
+        {% if host_type == 'Network' %}
+        <HostType>Network</HostType>
+        <IPAddress>{{ ip_address }}</IPAddress>
+        <Subnet>{{ mask }}</Subnet>
+        {% endif %}
+        {% if host_type == 'IPRange' %}
+        <HostType>IPRange</HostType>
+        <StartIPAddress>{{ start_ip }}</StartIPAddress>
+        <EndIPAddress>{{ end_ip }}</EndIPAddress>
+        {% endif %}
     </IPHost>
    </Set>
 </Request>

--- a/sophosfirewall_python/tests/functional.py
+++ b/sophosfirewall_python/tests/functional.py
@@ -22,10 +22,11 @@ from sophosfirewall_python.firewallapi import SophosFirewall
 from sophosfirewall_python.api_client import (
     SophosFirewallZeroRecords,
     SophosFirewallAuthFailure,
-    SophosFirewallAPIError
+    SophosFirewallAPIError,
 )
 
 API_VERSION = os.environ["API_VERSION"]
+
 
 @pytest.fixture(scope="session", autouse=True)
 def setup(request):
@@ -80,9 +81,7 @@ def setup(request):
 def test_login(setup):
     """Test login() method."""
 
-    expected_result = {
-        "status": "Authentication Successful"
-        }
+    expected_result = {"status": "Authentication Successful"}
 
     response = setup.login()
 
@@ -92,10 +91,10 @@ def test_login(setup):
 def test_create_ip_host(setup):
     """Test create_ip_host method."""
 
-    expected_result = {     
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+    expected_result = {
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
 
     hosts = [
         {"name": "FUNC_TESTHOST1", "ip": "1.1.1.1"},
@@ -103,152 +102,139 @@ def test_create_ip_host(setup):
     ]
     for host in hosts:
         response = setup.create_ip_host(name=host["name"], ip_address=host["ip"])
-        assert (response["Response"]["IPHost"]["Status"]
-            == expected_result
-        )
+        assert response["Response"]["IPHost"]["Status"] == expected_result
 
 
 def test_create_ip_hostgroup(setup):
     """Test create_ip_hostgroup method."""
 
-    expected_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully."
-            }
+    expected_result = {"@code": "200", "#text": "Configuration applied successfully."}
     response = setup.create_ip_hostgroup(
-            name="FUNC_TESTGROUP1",
-            description="Test group created during functional test",
-            host_list=["FUNC_TESTHOST1"],
-        )
-    assert (response["Response"]["IPHostGroup"]["Status"]
-        == expected_result
+        name="FUNC_TESTGROUP1",
+        description="Test group created during functional test",
+        host_list=["FUNC_TESTHOST1"],
     )
+    assert response["Response"]["IPHostGroup"]["Status"] == expected_result
+
 
 def test_create_fqdn_host(setup):
     """Test create_fqdn_host method."""
 
     expected_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
-
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
 
     fqdn_hosts = [
         {"name": "FUNC_TESTFQDNHOST1", "fqdn": "*.test1.com"},
         {"name": "FUNC_TESTFQDNHOST2", "fqdn": "*.test2.com"},
     ]
     for host in fqdn_hosts:
-        response = setup.create_fqdn_host(name=host["name"], description="Created during automated functional testing", fqdn=host["fqdn"])
-        assert (
-            response["Response"]["FQDNHost"]["Status"]
-            == expected_result
+        response = setup.create_fqdn_host(
+            name=host["name"],
+            description="Created during automated functional testing",
+            fqdn=host["fqdn"],
         )
+        assert response["Response"]["FQDNHost"]["Status"] == expected_result
+
 
 def test_create_fqdn_hostgroup(setup):
     """Test create_fqdn_hostgroup method."""
 
     expected_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
 
     response = setup.create_fqdn_hostgroup(
-            name="FUNC_TESTFQDNGROUP1",
-            description="Test group created during functional test",
-            fqdn_host_list=["FUNC_TESTFQDNHOST1"],
-        )
-    assert (response["Response"]["FQDNHostGroup"]["Status"]
-        == expected_result
+        name="FUNC_TESTFQDNGROUP1",
+        description="Test group created during functional test",
+        fqdn_host_list=["FUNC_TESTFQDNHOST1"],
     )
+    assert response["Response"]["FQDNHostGroup"]["Status"] == expected_result
+
 
 def test_create_ip_network(setup):
     """Test create_ip_network method."""
 
     expected_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
 
     response = setup.create_ip_network(
-            name="FUNC_TESTNETWORK1",
-            ip_network="1.1.1.0",
-            mask="255.255.255.0",
-        )
-    assert (
-        response["Response"]["IPHost"]["Status"]
-        == expected_result
+        name="FUNC_TESTNETWORK1",
+        ip_network="1.1.1.0",
+        mask="255.255.255.0",
     )
+    assert response["Response"]["IPHost"]["Status"] == expected_result
 
 
 def test_create_ip_range(setup):
     """Test create_ip_range method."""
 
     expected_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
     response = setup.create_ip_range(
-            name="FUNC_TESTNETWORK2", start_ip="2.2.2.1", end_ip="2.2.2.10"
-        )
-    assert (response["Response"]["IPHost"]["Status"]  
-        == expected_result
+        name="FUNC_TESTNETWORK2", start_ip="2.2.2.1", end_ip="2.2.2.10"
     )
+    assert response["Response"]["IPHost"]["Status"] == expected_result
 
 
 def test_create_service(setup):
     """Test create_service method."""
 
     expected_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
 
     service_list = [
         {
             "name": "FUNC_TESTSVC1",
             "service_type": "TCPorUDP",
-            "service_list": [{"dst_port": 1234, "protocol": "tcp"}]
+            "service_list": [{"dst_port": 1234, "protocol": "tcp"}],
         },
         {
             "name": "FUNC_TESTSVC2",
             "service_type": "TCPorUDP",
-            "service_list": [{"dst_port": 5555, "protocol": "tcp"}]
-        }
+            "service_list": [{"dst_port": 5555, "protocol": "tcp"}],
+        },
     ]
 
     for service in service_list:
-        response = setup.create_service(name=service["name"], 
-                                 service_type=service["service_type"], 
-                                 service_list=service["service_list"])
-        assert (
-            response["Response"]["Services"]["Status"]
-            == expected_result
+        response = setup.create_service(
+            name=service["name"],
+            service_type=service["service_type"],
+            service_list=service["service_list"],
         )
+        assert response["Response"]["Services"]["Status"] == expected_result
+
 
 def test_create_service_group(setup):
     """Test create_servicegroup method."""
 
     expected_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
     response = setup.create_service_group(
-            name="FUNC_TESTSVCGROUP1",
-            description="Test group created during functional test",
-            service_list=["FUNC_TESTSVC1"],
-        )
-    assert (
-        response["Response"]["ServiceGroup"]["Status"]
-        == expected_result
+        name="FUNC_TESTSVCGROUP1",
+        description="Test group created during functional test",
+        service_list=["FUNC_TESTSVC1"],
     )
+    assert response["Response"]["ServiceGroup"]["Status"] == expected_result
+
 
 def test_create_rule(setup):
     """Test create_rule method."""
 
     expected_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
 
     rule_params = dict(
         rulename="FUNC_TESTRULE1",
@@ -263,189 +249,178 @@ def test_create_rule(setup):
         service_list=["FUNC_TESTSVC1"],
     )
     response = setup.create_rule(rule_params=rule_params)
-    assert  response["Response"]["FirewallRule"]["Status"] == expected_result
+    assert response["Response"]["FirewallRule"]["Status"] == expected_result
 
 
 def test_create_urlgroup(setup):
     """Test create_urlgroup method."""
 
     expected_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
     response = setup.create_urlgroup(
-            name="FUNC_URLGROUP1", domain_list=["test1.com", "test2.com"]
-        )
-    assert (response["Response"]["WebFilterURLGroup"]["Status"]
-        == expected_result
+        name="FUNC_URLGROUP1", domain_list=["test1.com", "test2.com"]
     )
+    assert response["Response"]["WebFilterURLGroup"]["Status"] == expected_result
 
 
 def test_create_user(setup):
     """Test create_user method."""
 
     expected_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
-    
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
+
     response = setup.create_user(
-            user="FUNC_TESTUSER1",
-            name="FUNC_TESTUSER1",
-            description="Functional Testing User 1",
-            user_password="P@ssw0rd12345",
-            user_type="Administrator",
-            profile="Administrator",
-            group="Open Group",
-            email="test.user@sophos.com",
-        )
-    assert (
-        response["Response"]["User"]["Status"]
-        == expected_result
+        user="FUNC_TESTUSER1",
+        name="FUNC_TESTUSER1",
+        description="Functional Testing User 1",
+        user_password="P@ssw0rd12345",
+        user_type="Administrator",
+        profile="Administrator",
+        group="Open Group",
+        email="test.user@sophos.com",
     )
+    assert response["Response"]["User"]["Status"] == expected_result
 
 
 def test_update_ip_hostgroup(setup):
     """Test update_ip_hostgroup method."""
 
     update_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
 
     get_result = {
-                "@transactionid": "",
-                "Name": "FUNC_TESTGROUP1",
-                "Description": "Test group created during functional test",
-                "HostList": {"Host": ["FUNC_TESTHOST1", "FUNC_TESTHOST2"]},
-                "IPFamily": "IPv4",
-            }
+        "@transactionid": "",
+        "Name": "FUNC_TESTGROUP1",
+        "Description": "Test group created during functional test",
+        "HostList": {"Host": ["FUNC_TESTHOST1", "FUNC_TESTHOST2"]},
+        "IPFamily": "IPv4",
+    }
 
-    response = setup.update_ip_hostgroup(name="FUNC_TESTGROUP1", host_list=["FUNC_TESTHOST2"])
-    assert (
-        response["Response"]["IPHostGroup"]["Status"]
-        == update_result
+    response = setup.update_ip_hostgroup(
+        name="FUNC_TESTGROUP1", host_list=["FUNC_TESTHOST2"]
     )
+    assert response["Response"]["IPHostGroup"]["Status"] == update_result
 
     response = setup.get_ip_hostgroup(name="FUNC_TESTGROUP1")
     assert response["Response"]["IPHostGroup"] == get_result
+
 
 def test_update_fqdn_hostgroup(setup):
     """Test update_fqdn_hostgroup method."""
 
     update_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
 
     get_result = {
-                "@transactionid": "",
-                "Name": "FUNC_TESTFQDNGROUP1",
-                "Description": "Test group created during functional test",
-                "FQDNHostList": {"FQDNHost": ["FUNC_TESTFQDNHOST1", "FUNC_TESTFQDNHOST2"]}
-            }
+        "@transactionid": "",
+        "Name": "FUNC_TESTFQDNGROUP1",
+        "Description": "Test group created during functional test",
+        "FQDNHostList": {"FQDNHost": ["FUNC_TESTFQDNHOST1", "FUNC_TESTFQDNHOST2"]},
+    }
 
-    response = setup.update_fqdn_hostgroup(name="FUNC_TESTFQDNGROUP1", fqdn_host_list=["FUNC_TESTFQDNHOST2"])
-    assert (
-        response["Response"]["FQDNHostGroup"]["Status"]
-        == update_result
+    response = setup.update_fqdn_hostgroup(
+        name="FUNC_TESTFQDNGROUP1", fqdn_host_list=["FUNC_TESTFQDNHOST2"]
     )
+    assert response["Response"]["FQDNHostGroup"]["Status"] == update_result
 
     response = setup.get_fqdn_hostgroup(name="FUNC_TESTFQDNGROUP1")
-    assert  response["Response"]["FQDNHostGroup"] == get_result
+    assert response["Response"]["FQDNHostGroup"] == get_result
+
 
 def test_update_service_group(setup):
     """Test update_servicegroup method."""
 
     update_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
 
     get_result = {
-                "@transactionid": "",
-                "Name": "FUNC_TESTSVCGROUP1",
-                "Description": "Test group created during functional test",
-                "ServiceList": {"Service": ["FUNC_TESTSVC1", "FUNC_TESTSVC2"]}
-            }
-    response = setup.update_service_group(name="FUNC_TESTSVCGROUP1", service_list=["FUNC_TESTSVC2"])
-    assert (
-        response["Response"]["ServiceGroup"]["Status"]
-        == update_result
+        "@transactionid": "",
+        "Name": "FUNC_TESTSVCGROUP1",
+        "Description": "Test group created during functional test",
+        "ServiceList": {"Service": ["FUNC_TESTSVC1", "FUNC_TESTSVC2"]},
+    }
+    response = setup.update_service_group(
+        name="FUNC_TESTSVCGROUP1", service_list=["FUNC_TESTSVC2"]
     )
+    assert response["Response"]["ServiceGroup"]["Status"] == update_result
 
     response = setup.get_service_group(name="FUNC_TESTSVCGROUP1")
-    assert  response["Response"]["ServiceGroup"] == get_result
+    assert response["Response"]["ServiceGroup"] == get_result
+
 
 def test_update_urlgroup(setup):
     """Test update_urlgroup method."""
 
     update_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
 
     get_result = {
-                "@transactionid": "",
-                "Name": "FUNC_URLGROUP1",
-                "Description": None,
-                "IsDefault": "No",
-                "URLlist": {"URL": ["test1.com", "test2.com", "test3.com"]}
+        "@transactionid": "",
+        "Name": "FUNC_URLGROUP1",
+        "Description": None,
+        "IsDefault": "No",
+        "URLlist": {"URL": ["test1.com", "test2.com", "test3.com"]},
     }
 
     response = setup.update_urlgroup(name="FUNC_URLGROUP1", domain_list=["test3.com"])
-    assert (
-        response["Response"]["WebFilterURLGroup"]["Status"]
-        == update_result
-    )
+    assert response["Response"]["WebFilterURLGroup"]["Status"] == update_result
 
-    response = setup.get_urlgroup(name="FUNC_URLGROUP1") 
+    response = setup.get_urlgroup(name="FUNC_URLGROUP1")
     assert response["Response"]["WebFilterURLGroup"] == get_result
+
 
 def test_update_service(setup):
     """Test update_service method."""
 
     update_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
 
     get_result = {
-                "@transactionid": "",
-                "Name": "FUNC_TESTSVC1",
-                "Description": None,
-                "Type": "TCPorUDP",
-                "ServiceDetails": {
-                    "ServiceDetail": [{
-                        "SourcePort": "1:65535",
-                        "DestinationPort": "1234",
-                        "Protocol": "TCP"
-                    },
-                    {
-                        "SourcePort": "1:65535",
-                        "DestinationPort": "2222",
-                        "Protocol": "TCP"
-                    }]
-                },
-            }
+        "@transactionid": "",
+        "Name": "FUNC_TESTSVC1",
+        "Description": None,
+        "Type": "TCPorUDP",
+        "ServiceDetails": {
+            "ServiceDetail": [
+                {"SourcePort": "1:65535", "DestinationPort": "1234", "Protocol": "TCP"},
+                {"SourcePort": "1:65535", "DestinationPort": "2222", "Protocol": "TCP"},
+            ]
+        },
+    }
 
-    response = setup.update_service(name="FUNC_TESTSVC1", service_type="TCPorUDP", service_list=[{"dst_port": "2222","protocol": "TCP"}])
-    assert (
-        response["Response"]["Services"]["Status"]
-        == update_result
+    response = setup.update_service(
+        name="FUNC_TESTSVC1",
+        service_type="TCPorUDP",
+        service_list=[{"dst_port": "2222", "protocol": "TCP"}],
     )
+    assert response["Response"]["Services"]["Status"] == update_result
 
     response = setup.get_service(name="FUNC_TESTSVC1")
-    assert  response["Response"]["Services"] == get_result
+    assert response["Response"]["Services"] == get_result
+
 
 def test_update_service_acl(setup):
     """Test update_service_acl method."""
 
     update_result = {
-                    "@code": "200",
-                    "#text": "Configuration applied successfully.",
-                }
-    
+        "@code": "200",
+        "#text": "Configuration applied successfully.",
+    }
+
     response = setup.update_service_acl(host_list=["FUNC_TESTHOST1"])
     assert response["Response"]["LocalServiceACL"]["Status"] == update_result
 

--- a/sophosfirewall_python/tests/functional.py
+++ b/sophosfirewall_python/tests/functional.py
@@ -18,16 +18,14 @@ version is expected to be seen during testing.
 """
 import os
 import pytest
-from sophosfirewall_python.firewallapi import (
-    SophosFirewall,
+from sophosfirewall_python.firewallapi import SophosFirewall
+from sophosfirewall_python.api_client import (
     SophosFirewallZeroRecords,
     SophosFirewallAuthFailure,
-    SophosFirewallAPIError,
+    SophosFirewallAPIError
 )
 
-
 API_VERSION = os.environ["API_VERSION"]
-
 
 @pytest.fixture(scope="session", autouse=True)
 def setup(request):

--- a/sophosfirewall_python/tests/unittests.py
+++ b/sophosfirewall_python/tests/unittests.py
@@ -19,6 +19,7 @@ from sophosfirewall_python.api_client import (
 from sophosfirewall_python.backup import Backup
 from sophosfirewall_python.admin import AclRule
 
+
 class TestAPIClient(unittest.TestCase):
     """Tests for APIClient module"""
 
@@ -29,8 +30,9 @@ class TestAPIClient(unittest.TestCase):
             password="fakepassword",
             hostname="fakehostname",
             port=4444,
-            verify=False
+            verify=False,
         )
+
     @patch("sophosfirewall_python.api_client.requests")
     def test_post(self, mocked_requests):
         """Test _post() method"""
@@ -322,6 +324,7 @@ class TestAPIClient(unittest.TestCase):
             == expected_result
         )
 
+
 class TestSophosFirewall(unittest.TestCase):
     """Tests for SophosFirewall module"""
 
@@ -507,27 +510,38 @@ class TestSophosFirewall(unittest.TestCase):
     def test_update_backup(self, mocked_get_backup, mocked_post):
         """Test update_backup() method"""
         mock_get = MagicMock()
-        mock_get.__getitem__.return_value = {'Response': {'@APIVersion': '2000.1',
-                '@IPS_CAT_VER': '1',
-                '@TOKEN': '$sfos$3$0$N=8000,r=8,p=1$w0k27Tt1Wv2vDfNp4S9b27Hsn0fu4JFba_srkvYE_6635dbp93vVAJUjJgWFRJMRTDicjYHZM2yL-W-apRZCUao5p-CeQfk3Bm1mB9YzyD_ksThJTMVata5iJK-vsJ3s1TgebibZQauWmJ2soe09tMq5WPBsaImt73yDyIcfIGqkJ27aOpTz7htq-L4rXsLs5s-Ad_f9CNWw7vfAI71TUUTLC8k_yKAozDjZ0T44_78~',
-                'Login': {'status': 'Authentication Successful'},
-                'BackupRestore': {'@transactionid': '',
-                'ScheduleBackup': {'BackupMode': 'FTP',
-                    'BackupPrefix': 'None',
-                    'FtpPath': 'test/backup',
-                    'Username': 'test123',
-                    'FTPServer': '1.1.1.1',
-                    'Password': {'@hashform': 'mode1',
-                    '#text': '$sfos$7$0$_uP4crmO9IvUxbbRdwJ1omfejijPzFh3I0EZq3_yUjsamDMk4VDXL0q8E8n1aiFeNdwemUPZA2WWWABH-PGAIA~~W0sy2lgIkTrO0sJvopvqb-w9sShSQLhq52AixbyPVuE~'},
-                    'EmailAddress': None,
-                    'BackupFrequency': 'Daily',
-                    'Day': None,
-                    'Hour': '10',
-                    'Minute': '00',
-                    'Date': None,
-                    'EncryptionPassword': {'@hashform': 'mode1',
-                    '#text': '$sfos$7$0$uC9DHfNOAliRvH-9BAUlKgwMe73tSLN33vTamdnKafjpX_b5ZjsGzW83OJ3LCIQPiYHf1Q9AIH1Il0UUoS5-hzdVX9gQWxDQ6HTFBqa0_h0~5XNN3_fPiAQT2Ry3ngsK8vi8KDh1MeXaOI4UkFQvIN4~'
-                    }}}}}
+        mock_get.__getitem__.return_value = {
+            "Response": {
+                "@APIVersion": "2000.1",
+                "@IPS_CAT_VER": "1",
+                "@TOKEN": "$sfos$3$0$N=8000,r=8,p=1$w0k27Tt1Wv2vDfNp4S9b27Hsn0fu4JFba_srkvYE_6635dbp93vVAJUjJgWFRJMRTDicjYHZM2yL-W-apRZCUao5p-CeQfk3Bm1mB9YzyD_ksThJTMVata5iJK-vsJ3s1TgebibZQauWmJ2soe09tMq5WPBsaImt73yDyIcfIGqkJ27aOpTz7htq-L4rXsLs5s-Ad_f9CNWw7vfAI71TUUTLC8k_yKAozDjZ0T44_78~",
+                "Login": {"status": "Authentication Successful"},
+                "BackupRestore": {
+                    "@transactionid": "",
+                    "ScheduleBackup": {
+                        "BackupMode": "FTP",
+                        "BackupPrefix": "None",
+                        "FtpPath": "test/backup",
+                        "Username": "test123",
+                        "FTPServer": "1.1.1.1",
+                        "Password": {
+                            "@hashform": "mode1",
+                            "#text": "$sfos$7$0$_uP4crmO9IvUxbbRdwJ1omfejijPzFh3I0EZq3_yUjsamDMk4VDXL0q8E8n1aiFeNdwemUPZA2WWWABH-PGAIA~~W0sy2lgIkTrO0sJvopvqb-w9sShSQLhq52AixbyPVuE~",
+                        },
+                        "EmailAddress": None,
+                        "BackupFrequency": "Daily",
+                        "Day": None,
+                        "Hour": "10",
+                        "Minute": "00",
+                        "Date": None,
+                        "EncryptionPassword": {
+                            "@hashform": "mode1",
+                            "#text": "$sfos$7$0$uC9DHfNOAliRvH-9BAUlKgwMe73tSLN33vTamdnKafjpX_b5ZjsGzW83OJ3LCIQPiYHf1Q9AIH1Il0UUoS5-hzdVX9gQWxDQ6HTFBqa0_h0~5XNN3_fPiAQT2Ry3ngsK8vi8KDh1MeXaOI4UkFQvIN4~",
+                        },
+                    },
+                },
+            }
+        }
 
         mock_response = Mock()
         mock_response.content = (

--- a/sophosfirewall_python/tests/unittests.py
+++ b/sophosfirewall_python/tests/unittests.py
@@ -9,27 +9,29 @@ permissions and limitations under the License.
 """
 import unittest
 from unittest.mock import patch, Mock, MagicMock
-from firewallapi import (
-    SophosFirewall,
+from sophosfirewall_python.firewallapi import SophosFirewall
+from sophosfirewall_python.api_client import (
+    APIClient,
     SophosFirewallZeroRecords,
     SophosFirewallAuthFailure,
     SophosFirewallAPIError,
 )
+from sophosfirewall_python.backup import Backup
+from sophosfirewall_python.admin import AclRule
 
-
-class TestSophosFirewall(unittest.TestCase):
-    """Tests for SophosFirewall module"""
+class TestAPIClient(unittest.TestCase):
+    """Tests for APIClient module"""
 
     def setUp(self):
         """Test setup"""
-        self.fw = SophosFirewall(
+        self.fw = APIClient(
             username="fakeusername",
             password="fakepassword",
             hostname="fakehostname",
             port=4444,
+            verify=False
         )
-
-    @patch("firewallapi.requests")
+    @patch("sophosfirewall_python.api_client.requests")
     def test_post(self, mocked_requests):
         """Test _post() method"""
         mock_response = Mock()
@@ -94,7 +96,7 @@ class TestSophosFirewall(unittest.TestCase):
 
         assert self.fw._post(xmldata=payload).content == expected_result
 
-    @patch("firewallapi.requests")
+    @patch("sophosfirewall_python.api_client.requests")
     def test_auth_failure(self, mocked_requests):
         """Test _post() method"""
         mock_response = Mock()
@@ -135,7 +137,7 @@ class TestSophosFirewall(unittest.TestCase):
             SophosFirewallAuthFailure, self.fw._post, {"xmldata": payload}
         )
 
-    @patch.object(SophosFirewall, "_post")
+    @patch.object(APIClient, "_post")
     def test_get_tag(self, mocked_post):
         """Test get_tag() method"""
         mock_response = Mock()
@@ -192,7 +194,7 @@ class TestSophosFirewall(unittest.TestCase):
         }
         assert self.fw.get_tag("IPHost") == expected_result
 
-    @patch.object(SophosFirewall, "_post")
+    @patch.object(APIClient, "_post")
     def test_get_tag_with_filter(self, mocked_post):
         """Test get_tag_with_filter() method"""
         mock_response = Mock()
@@ -239,7 +241,7 @@ class TestSophosFirewall(unittest.TestCase):
             == expected_result
         )
 
-    @patch.object(SophosFirewall, "_post")
+    @patch.object(APIClient, "_post")
     def test_no_records(self, mocked_post):
         """Test get_tag_with_filter() method when no records available"""
         mock_response = Mock()
@@ -268,7 +270,7 @@ class TestSophosFirewall(unittest.TestCase):
             SophosFirewallZeroRecords, self.fw.get_tag_with_filter, **kwargs
         )
 
-    @patch.object(SophosFirewall, "_post")
+    @patch.object(APIClient, "_post")
     def test_submit_template(self, mocked_post):
         """Test submit_template() method"""
         mock_response = Mock()
@@ -320,7 +322,19 @@ class TestSophosFirewall(unittest.TestCase):
             == expected_result
         )
 
-    @patch.object(SophosFirewall, "_post")
+class TestSophosFirewall(unittest.TestCase):
+    """Tests for SophosFirewall module"""
+
+    def setUp(self):
+        """Test setup"""
+        self.fw = SophosFirewall(
+            username="fakeusername",
+            password="fakepassword",
+            hostname="fakehostname",
+            port=4444,
+        )
+
+    @patch.object(APIClient, "_post")
     def test_login(self, mocked_post):
         """Test login() method"""
         mock_response = Mock()
@@ -349,7 +363,7 @@ class TestSophosFirewall(unittest.TestCase):
 
         assert self.fw.login() == expected_result
 
-    @patch.object(SophosFirewall, "_post")
+    @patch.object(APIClient, "_post")
     def test_create_rule(self, mocked_post):
         """Test create_rule() method"""
         mock_response = Mock()
@@ -400,7 +414,7 @@ class TestSophosFirewall(unittest.TestCase):
 
         assert self.fw.create_rule(rule_params=rule_params) == expected_result
 
-    @patch.object(SophosFirewall, "_post")
+    @patch.object(APIClient, "_post")
     def test_failed_create_rule(self, mocked_post):
         """Test failed creation response"""
         mock_response = Mock()
@@ -439,7 +453,7 @@ class TestSophosFirewall(unittest.TestCase):
             SophosFirewallAPIError, self.fw.create_rule, {"rule_params": rule_params}
         )
 
-    @patch.object(SophosFirewall, "_post")
+    @patch.object(APIClient, "_post")
     def test_create_user(self, mocked_post):
         """Test create_user() method"""
         mock_response = Mock()
@@ -488,8 +502,8 @@ class TestSophosFirewall(unittest.TestCase):
 
         assert self.fw.create_user(**user_params) == expected_result
 
-    @patch.object(SophosFirewall, "_post")
-    @patch.object(SophosFirewall, "get_backup")
+    @patch.object(APIClient, "_post")
+    @patch.object(Backup, "get")
     def test_update_backup(self, mocked_get_backup, mocked_post):
         """Test update_backup() method"""
         mock_get = MagicMock()
@@ -565,12 +579,10 @@ class TestSophosFirewall(unittest.TestCase):
             }
         }
 
-
-
         assert self.fw.update_backup(backup_params=backup_params) == expected_result
 
-    @patch.object(SophosFirewall, "_post")
-    @patch.object(SophosFirewall, "get_acl_rule")
+    @patch.object(APIClient, "_post")
+    @patch.object(AclRule, "get")
     def test_update_service_acl(self, mocked_get_acl_rule, mocked_post):
         """Test update_service_acl() method"""
         mock_get = MagicMock()
@@ -646,7 +658,7 @@ class TestSophosFirewall(unittest.TestCase):
             == expected_result
         )
 
-    @patch.object(SophosFirewall, "_post")
+    @patch.object(APIClient, "_post")
     @patch.object(SophosFirewall, "get_urlgroup")
     def test_update_urlgroup(self, mocked_get_urlgroup, mocked_post):
         """Test update_urlgroup() method"""
@@ -704,7 +716,7 @@ class TestSophosFirewall(unittest.TestCase):
             == expected_result
         )
 
-    @patch.object(SophosFirewall, "_post")
+    @patch.object(APIClient, "_post")
     def test_get_ip_host_all(self, mocked_post):
         """Test get_ip_host() method for all hosts"""
         mock_response = Mock()
@@ -761,7 +773,7 @@ class TestSophosFirewall(unittest.TestCase):
         }
         assert self.fw.get_ip_host() == expected_result
 
-    @patch.object(SophosFirewall, "_post")
+    @patch.object(APIClient, "_post")
     def test_get_ip_host_queryparams(self, mocked_post):
         """Test get_tag_ip_host() method with query parameters"""
         mock_response = Mock()
@@ -803,7 +815,7 @@ class TestSophosFirewall(unittest.TestCase):
         }
         assert self.fw.get_ip_host(name="TEST1") == expected_result
 
-    @patch.object(SophosFirewall, "_post")
+    @patch.object(APIClient, "_post")
     def test_remove(self, mocked_post):
         """Test remove() method"""
         mock_response = Mock()
@@ -844,8 +856,8 @@ class TestSophosFirewall(unittest.TestCase):
 
         assert self.fw.remove(xml_tag="IPHost", name="TESTHOST") == expected_result
 
-    @patch.object(SophosFirewall, "_post")
-    @patch.object(SophosFirewall, "get_tag_with_filter")
+    @patch.object(APIClient, "_post")
+    @patch.object(APIClient, "get_tag_with_filter")
     def test_update(self, mocked_get_tag_with_filter, mocked_post):
         """Test update() method"""
         mock_get = MagicMock()

--- a/sophosfirewall_python/utils.py
+++ b/sophosfirewall_python/utils.py
@@ -33,11 +33,10 @@ class Utils:
         
     @staticmethod
     def validate_ip_address(ip_address):
-        """Validate IP network and mask
+        """Validate IP address.
 
         Args:
-            ip_subnet (str): IP network address
-            mask (str): Subnet mask
+            ip_address (str): IP address
 
         Raises:
             SophosFirewallIPAddressingError: Custom error class

--- a/sophosfirewall_python/utils.py
+++ b/sophosfirewall_python/utils.py
@@ -1,0 +1,50 @@
+"""
+Copyright 2023 Sophos Ltd.  All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+"""
+from ipaddress import IPv4Network, IPv4Address
+
+class SophosFirewallIPAddressingError(Exception):
+    """Error raised when invalid IP address detected"""
+
+class Utils:
+    """Class containing utility methods."""
+    @staticmethod
+    def validate_ip_network(ip_subnet, mask):
+        """Validate IP network and mask
+
+        Args:
+            ip_subnet (str): IP network address
+            mask (str): Subnet mask
+
+        Raises:
+            SophosFirewallIPAddressingError: Custom error class
+        """
+        try:
+            IPv4Network(f"{ip_subnet}/{mask}")
+        except Exception as exc:
+            raise SophosFirewallIPAddressingError(
+                f"Invalid network or mask provided - {ip_subnet}/{mask}"
+            ) from exc
+        
+    @staticmethod
+    def validate_ip_address(ip_address):
+        """Validate IP network and mask
+
+        Args:
+            ip_subnet (str): IP network address
+            mask (str): Subnet mask
+
+        Raises:
+            SophosFirewallIPAddressingError: Custom error class
+        """
+        try:
+            IPv4Address(ip_address)
+        except Exception as exc:
+            raise SophosFirewallIPAddressingError(
+                f"Invalid IP address provided - {ip_address}"
+            ) from exc

--- a/sophosfirewall_python/utils.py
+++ b/sophosfirewall_python/utils.py
@@ -8,11 +8,14 @@ permissions and limitations under the License.
 """
 from ipaddress import IPv4Network, IPv4Address
 
+
 class SophosFirewallIPAddressingError(Exception):
     """Error raised when invalid IP address detected"""
 
+
 class Utils:
     """Class containing utility methods."""
+
     @staticmethod
     def validate_ip_network(ip_subnet, mask):
         """Validate IP network and mask
@@ -30,7 +33,7 @@ class Utils:
             raise SophosFirewallIPAddressingError(
                 f"Invalid network or mask provided - {ip_subnet}/{mask}"
             ) from exc
-        
+
     @staticmethod
     def validate_ip_address(ip_address):
         """Validate IP address.


### PR DESCRIPTION
This PR refactors the `firewallapi.py` which had grown to 1500+ lines, splitting the heavy-lifting of doing the CRUD operations into separate modules while maintaining backward compatibility with external programs already using the SDK.  This will make it easier to maintain and scale better as we add more features and capabilities in the future.  The bulk of `firewallapi.py` is now comments, which are used to generate the documentation automatically at build time.  

This update also adds the ability to specify HostType when creating an IP Host using the `create_ip_host` function. IP hosts can be created as type IP, IPRange, or Network, with the default being IP.  The IPRange or Network options offer the same functionality as `create_ip_range` and `create_ip_network` methods, which will be kept for backward compatibility.  