### PR TITLE
Fix: Updates and additions for working with Local Service ACL Exception rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.41"
+version = "0.1.42"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/admin.py
+++ b/sophosfirewall_python/admin.py
@@ -6,16 +6,16 @@ Unless required by applicable law or agreed to in writing, software distributed 
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
-
+from sophosfirewall_python.utils import Utils
 
 class AclRule:
-    """Class for working with ACL Exception Rules."""
+    """Class for working with Local Service ACL Exception Rules."""
 
     def __init__(self, api_client):
         self.client = api_client
 
     def get(self, name=None, operator="="):
-        """Get ACL rules
+        """Get Local ACL Exception rules
 
         Args:
             name (str, optional): Name of rule to retrieve. Returns all if not specified.
@@ -26,45 +26,120 @@ class AclRule:
         """
         if name:
             return self.client.get_tag_with_filter(
-                xml_tag="LocalServiceACL", key="Name", value=name, operator=operator
+                xml_tag="LocalServiceACL", key="RuleName", value=name, operator=operator
             )
         return self.client.get_tag(xml_tag="LocalServiceACL")
-
-    def update(self, host_list, service_list, action, debug):
-        """Update Local Service ACL (System > Administration > Device Access > Local service ACL exception)
+    
+    def create(self, name, description, position, source_zone, source_list, dest_list, service_list, action, debug):
+        """Create Local Service ACL Exception Rule (System > Administration > Device Access > Local service ACL exception)
 
         Args:
-            host_list (list, optional): List of network or host groups. Defaults to [].
-            service_list (list, optional): List of services. Defaults to [].
-            action (str, optional): Indicate 'add' or 'remove' from list. Default is 'add'.
-            verify (bool, optional): SSL Certificate checking. Defaults to True.
+            name (str): Name of the ACL exception rule to update.
+            description (str): Rule description.
+            position (str): Location to place the ACL (Top or Bottom). 
+            source_zone (str): Source Zone. Defaults to Any. 
+            source_list (list, optional): List of source network or host groups. Defaults to None.
+            dest_list (list, optional): List of destination hosts. Defaults to None.
+            service_list (list, optional): List of services. Defaults to None.
+            action (str, optional): Accept or Drop. Default is Accept.
             debug (bool, optional): Enable debug mode. Defaults to False.
         """
+        template_vars = {
+            "name": name,
+            "description": description,
+            "position": position,
+            "source_zone": source_zone,
+            "source_list": source_list,
+            "dest_list": dest_list,
+            "service_list": service_list,
+            "action": action
+        }
+        resp = self.client.submit_template(
+            "createserviceacl.j2", template_vars=template_vars, debug=debug
+        )
+
+        return resp
+
+    def update(self, name, description, source_zone, source_list, dest_list, service_list, action, update_action, debug):
+        """Update Local Service ACL Exception Rule (System > Administration > Device Access > Local service ACL exception)
+
+        Args:
+            name (str): Name of the ACL rule to update.
+            description (str): Rule description.
+            source_zone (str): Name of the source zone. Defaults to None. 
+            source_list (list, optional): List of network or host groups. Defaults to [].
+            dest_list (list, optional): List of destinations. Defaults to [].
+            service_list (list, optional): List of services. Defaults to [].
+            action (str, optional): Accept or Drop.
+            update_action (str, optional): Indicate 'add' or 'remove' from list. Default is 'add'.
+            debug (bool, optional): Enable debug mode. Defaults to False.
+        """
+        if update_action:
+            self.client.validate_arg(
+                arg_name="update_action", arg_value=update_action, valid_choices=["add", "remove"]
+            )
+
         if action:
             self.client.validate_arg(
-                arg_name="action", arg_value=action, valid_choices=["add", "remove"]
+                arg_name="action", arg_value=action.lower(), valid_choices=["accept", "drop"]
             )
-        resp = self.get()
 
-        exist_hosts = resp["Response"]["LocalServiceACL"]["Hosts"]["Host"]
-        exist_services = resp["Response"]["LocalServiceACL"]["Services"]["Service"]
+        resp = self.get(name=name)
 
-        if not host_list:
-            host_list = []
+        if not source_zone:
+            source_zone = resp["Response"]["LocalServiceACL"]["SourceZone"]
+
+        if not description:
+            description = resp["Response"]["LocalServiceACL"]["Description"]
+
+        if not action:
+            action = resp["Response"]["LocalServiceACL"]["Action"]
+
+        if "Host" in resp["Response"]["LocalServiceACL"]["Hosts"]:
+            exist_sources = Utils.ensure_list(resp["Response"]["LocalServiceACL"]["Hosts"]["Host"])
+        else:
+            exist_sources = []
+        if "DstHost" in resp["Response"]["LocalServiceACL"]["Hosts"]:    
+            exist_dests = Utils.ensure_list(resp["Response"]["LocalServiceACL"]["Hosts"]["DstHost"])
+        else:
+            exist_dests = []
+        if "Service" in resp["Response"]["LocalServiceACL"]["Services"]:
+            exist_services = Utils.ensure_list(resp["Response"]["LocalServiceACL"]["Services"]["Service"])
+        else:
+            exist_services = []
+
+        if not source_list:
+            source_list = []
+        if not dest_list:
+            dest_list = []
         if not service_list:
             service_list = []
 
-        if action == "add":
+        if update_action == "add":
             template_vars = {
-                "host_list": exist_hosts + host_list,
+                "name": name,
+                "description": description,
+                "source_zone": source_zone,
+                "source_list": exist_sources + source_list,
+                "dest_list": exist_dests + dest_list,
                 "service_list": exist_services + service_list,
+                "action": action
             }
-        elif action == "remove":
-            for host in host_list:
-                exist_hosts.remove(host)
+        elif update_action == "remove":
+            for host in source_list:
+                exist_sources.remove(host)
+            for host in dest_list:
+                exist_dests.remove(host)
             for service in service_list:
                 exist_services.remove(service)
-            template_vars = {"host_list": exist_hosts, "service_list": exist_services}
+            template_vars = {
+                "name": name,
+                "description": description,
+                "source_zone": source_zone,
+                "source_list": exist_sources,
+                "dest_list": exist_dests,
+                "service_list": exist_services}
+
         resp = self.client.submit_template(
             "updateserviceacl.j2", template_vars=template_vars, debug=debug
         )

--- a/sophosfirewall_python/api_client.py
+++ b/sophosfirewall_python/api_client.py
@@ -251,12 +251,13 @@ class APIClient:
             return resp.content.decode()
         return xmltodict.parse(resp.content.decode())
 
-    def remove(self, xml_tag: str, name: str, output_format: str = "dict"):
+    def remove(self, xml_tag: str, name: str, key: str = "Name", output_format: str = "dict"):
         """Remove an object from the firewall.
 
         Args:
             xml_tag (str): The XML tag indicating the type of object to be removed.
             name (str): The name of the object to be removed.
+            key (str): The primary XML key that is used to look up the object. Defaults to Name.
             output_format (str): Output format. Valid options are "dict" or "xml". Defaults to dict.
         """
         payload = f"""
@@ -267,7 +268,7 @@ class APIClient:
             </Login>
             <Remove>
               <{xml_tag}>
-                <Name>{name}</Name>
+                <{key}>{name}</{key}>
               </{xml_tag}>
             </Remove>
         </Request>

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -101,15 +101,16 @@ class SophosFirewall:
         """
         return self.client.submit_template(filename, template_vars, template_dir, debug)
 
-    def remove(self, xml_tag: str, name: str, output_format: str = "dict"):
+    def remove(self, xml_tag: str, name: str, key: str = "Name", output_format: str = "dict"):
         """Remove an object from the firewall.
 
         Args:
             xml_tag (str): The XML tag indicating the type of object to be removed.
             name (str): The name of the object to be removed.
+            key (str): The primary XML key that is used to look up the object. Defaults to Name.
             output_format (str): Output format. Valid options are "dict" or "xml". Defaults to dict.
         """
-        return self.client.remove(xml_tag, name, output_format)
+        return self.client.remove(xml_tag, name, key, output_format)
 
     def update(
         self,
@@ -386,6 +387,39 @@ class SophosFirewall:
         return Service(self.client).get(name, operator, dst_proto, dst_port)
 
     # METHODS FOR OBJECT CREATION
+
+    def create_acl_rule(self,
+                         name: str,
+                         description: str = None,
+                         position: str = "Bottom",
+                         source_zone: str = "Any",
+                         source_list: list = None,
+                         dest_list: list = None,
+                         service_list: list = None,
+                         action: str = "Accept",
+                         debug: bool = False):
+        """Create Local Service ACL Exception Rule (System > Administration > Device Access > Local service ACL exception)
+
+        Args:
+            name (str): Name of the ACL exception rule to create.
+            description (str): Rule description. 
+            position (str): Location to place the ACL (Top or Bottom). 
+            source_zone (str): Source Zone. Defaults to Any. 
+            source_list (list, optional): List of source network or host groups. Defaults to None.
+            dest_list (list, optional): List of destination hosts. Defaults to None.
+            service_list (list, optional): List of services. Defaults to None.
+            action (str, optional): Accept or Drop. Default is Accept.
+            debug (bool, optional): Enable debug mode. Defaults to False.
+        """
+        return AclRule(self.client).create(name,
+                                           description, 
+                                           position, 
+                                           source_zone, 
+                                           source_list, 
+                                           dest_list, 
+                                           service_list, 
+                                           action, 
+                                           debug)
 
     def create_rule(self, rule_params: dict, debug: bool = False):
         """Create a firewall rule
@@ -799,20 +833,40 @@ class SophosFirewall:
         """
         return Backup(self.client).update(backup_params, debug)
 
-    def update_service_acl(
+    def update_acl_rule(
         self,
-        host_list: list = None,
+        name: str,
+        description: str = None,
+        source_zone: str = None,
+        source_list: list = None,
+        dest_list: list = None,
         service_list: list = None,
-        action: str = "add",
+        action: str = None,
+        update_action: str = "add",
         debug: bool = False,
     ):
-        """Update Local Service ACL (System > Administration > Device Access > Local service ACL exception)
+        """Update Local Service ACL Exception Rule (System > Administration > Device Access > Local service ACL exception)
 
         Args:
-            host_list (list, optional): List of network or host groups. Defaults to [].
+            name (str): Name of the ACL rule to update.
+            description (str): Rule description.
+            source_zone (str): Name of the source zone. Defaults to None. 
+            source_list (list, optional): List of network or host groups. Defaults to [].
+            dest_list (list, optional): List of destinations. Defaults to [].
             service_list (list, optional): List of services. Defaults to [].
-            action (str, optional): Indicate 'add' or 'remove' from list. Default is 'add'.
-            verify (bool, optional): SSL Certificate checking. Defaults to True.
+            action (str, optional): Accept or Drop.
+            update_action (str, optional): Indicate 'add' or 'remove' from list. Default is 'add'.
             debug (bool, optional): Enable debug mode. Defaults to False.
         """
-        return AclRule(self.client).update(host_list, service_list, action, debug)
+        params = {
+                    "name": name,
+                    "description": description,
+                    "source_zone": source_zone,
+                    "source_list": source_list,
+                    "dest_list": dest_list,
+                    "service_list": service_list,
+                    "action": action,
+                    "update_action": update_action,
+                    "debug": debug
+                  }
+        return AclRule(self.client).update(**params)

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -209,7 +209,7 @@ class SophosFirewall:
         return Vlan(self.client).get(name, operator)
 
     def get_acl_rule(self, name: str = None, operator: str = "="):
-        """Get ACL rules
+        """Get Local Service ACL Exception rule(s) (System > Administration > Device Access > Local service ACL exception)
 
         Args:
             name (str, optional): Name of rule to retrieve. Returns all if not specified.

--- a/sophosfirewall_python/templates/createserviceacl.j2
+++ b/sophosfirewall_python/templates/createserviceacl.j2
@@ -3,29 +3,34 @@
         <Username>{{username}}</Username>
         <Password >{{password}}</Password>
     </Login>
-    <Set operation="update"> 
+    <Set operation="add"> 
 		<LocalServiceACL>
 			<RuleName>{{ name }}</RuleName>
 			<Description>{{ description }}</Description>
+            <Position>{{ position }}</Position>
 			<IPFamily>IPv4</IPFamily>
+            {% if source_zone %}
 			<SourceZone>{{ source_zone }}</SourceZone>
+            {% endif %}
 			{% if source_list %}
 			<Hosts>
 				{% for host in source_list %}
 				<Host>{{ host }}</Host>
 				{% endfor %}
-				{% if dest_list %}
+                {% if dest_list %}
                 {% for dsthost in dest_list %}
                 <DstHost>{{ dsthost }}</DstHost>
                 {% endfor %}
                 {% endif %}
 			</Hosts>
 			{% endif %}
+            {% if service_list %}
 			<Services>
 				{% for service in service_list %}
 				<Service>{{ service }}</Service>
 				{% endfor %}
 			</Services>
+            {% endif %}
 			<Action>{{ action | lower }}</Action>
 		</LocalServiceACL>
    </Set>

--- a/sophosfirewall_python/utils.py
+++ b/sophosfirewall_python/utils.py
@@ -50,3 +50,17 @@ class Utils:
             raise SophosFirewallIPAddressingError(
                 f"Invalid IP address provided - {ip_address}"
             ) from exc
+    
+    @staticmethod
+    def ensure_list(val):
+        """Checks whether provided object is a string or a list.
+           If string, create a new list and append it to the list.
+           If list, just return the list as-is. 
+
+        Args:
+            val (str or list): A string or a list
+        """
+        if isinstance(val, str):
+            new_list = [val]
+            return new_list
+        return val


### PR DESCRIPTION
- Changed the `get_service_acl()` method to `get_acl_rule()`
- Added the ability for `get_acl_rule()` to look up an individual rule by name
- Added a `create_acl_rule()` method for addition of new rules
- Renamed `update_service_acl()` to `update_acl_rule()`
- Added ability to update a specified rule with `update_acl_rule()`
- Added the ability to update description, zone, destination host, and action (accept/drop) to `update_acl_rule()` 
- Version updated to v0.1.42