### PR TITLE
Fix: Updates for backward compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.42"
+version = "0.1.43"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -51,6 +51,11 @@ class SophosFirewall:
             port=port,
             verify=verify,
         )
+        self.username = self.client.username
+        self.password = self.client.password
+        self.hostname = self.client.hostname
+        self.port = self.client.port
+        self.verify = self.client.verify
 
     def login(self, output_format: str = "dict"):
         """Test login credentials.

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -134,7 +134,7 @@ class SophosFirewall:
     # METHODS FOR OBJECT RETRIEVAL (GET)
 
     def get_fw_rule(self, name: str = None, operator: str = "="):
-        """Get firewall rule(s)
+        """Get firewall rule(s). DEPRECATED: Use `get_rule()` instead. Will be removed in a later version.
 
         Args:
             name (str, optional): Firewall Rule name.  Returns all rules if not specified.

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -141,6 +141,15 @@ class SophosFirewall:
             operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
         """
         return FirewallRule(self.client).get(name=name, operator=operator)
+    
+    def get_rule(self, name: str = None, operator: str = "="):
+        """Get firewall rule(s)
+
+        Args:
+            name (str, optional): Firewall Rule name.  Returns all rules if not specified.
+            operator (str, optional): Operator for search. Default is "=". Valid operators: =, !=, like.
+        """
+        return FirewallRule(self.client).get(name=name, operator=operator)
 
     def get_ip_host(
         self, name: str = None, ip_address: str = None, operator: str = "="

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -10,7 +10,14 @@ permissions and limitations under the License.
 """
 
 import urllib3
-from sophosfirewall_python.api_client import APIClient
+from sophosfirewall_python.api_client import (
+    APIClient,
+    SophosFirewallZeroRecords,
+    SophosFirewallInvalidArgument,
+    SophosFirewallAPIError,
+    SophosFirewallAuthFailure,
+    SophosFirewallOperatorError
+)
 from sophosfirewall_python.firewallrule import FirewallRule
 from sophosfirewall_python.host import (
     IPHost,
@@ -879,3 +886,12 @@ class SophosFirewall:
                     "debug": debug
                   }
         return AclRule(self.client).update(**params)
+
+# Export the error classes for backward compatibility
+__all__ = [
+    "SophosFirewallZeroRecords",
+    "SophosFirewallAPIError",
+    "SophosFirewallAuthFailure",
+    "SophosFirewallInvalidArgument",
+    "SophosFirewallOperatorError",
+]


### PR DESCRIPTION
- The methods for getting and creating firewall rules were inconsistent. The get method is `get_fw_rule()` while the create is `create_rule()`. Added a `get_rule()` method while keeping the `get_fw_rule()` for backward compatibility. 
- Allow error classes to be imported from the `firewallapi.py` module even though they have been moved to `api_client()` for backward compatibility.  
- Define username, password, hostname, port, and verify attributes on the SophosFirewall object for backward compatibility.
- Update to version v0.1.43