### PR TITLE
Fix: Correct error with autogeneration of documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.43"
+version = "0.1.44"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -894,6 +894,7 @@ class SophosFirewall:
 
 # Export the error classes for backward compatibility
 __all__ = [
+    "SophosFirewall",
     "SophosFirewallZeroRecords",
     "SophosFirewallAPIError",
     "SophosFirewallAuthFailure",


### PR DESCRIPTION
Minor code fix to restore documentation for the `SophosFirewall` class. 