### PR TITLE
feat: add argument validation to create_ip_host() and replace capability to update_acl_rule()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.44"
+version = "0.1.45"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/admin.py
+++ b/sophosfirewall_python/admin.py
@@ -71,12 +71,12 @@ class AclRule:
             dest_list (list, optional): List of destinations. Defaults to [].
             service_list (list, optional): List of services. Defaults to [].
             action (str, optional): Accept or Drop.
-            update_action (str, optional): Indicate 'add' or 'remove' from list. Default is 'add'.
+            update_action (str, optional): Indicate whether to 'add' or 'remove' from source, dest, or service lists, or to 'replace' the lists. Default is 'add'.
             debug (bool, optional): Enable debug mode. Defaults to False.
         """
         if update_action:
             self.client.validate_arg(
-                arg_name="update_action", arg_value=update_action, valid_choices=["add", "remove"]
+                arg_name="update_action", arg_value=update_action, valid_choices=["add", "remove", "replace"]
             )
 
         if action:
@@ -123,6 +123,16 @@ class AclRule:
                 "source_list": exist_sources + source_list,
                 "dest_list": exist_dests + dest_list,
                 "service_list": exist_services + service_list,
+                "action": action
+            }
+        elif update_action == "replace":
+            template_vars = {
+                "name": name,
+                "description": description,
+                "source_zone": source_zone,
+                "source_list": source_list,
+                "dest_list": dest_list,
+                "service_list": service_list,
                 "action": action
             }
         elif update_action == "remove":

--- a/sophosfirewall_python/host.py
+++ b/sophosfirewall_python/host.py
@@ -51,6 +51,7 @@ class IPHost:
         Returns:
             dict: XML response converted to Python dictionary
         """
+        self.client.validate_arg("host_type", host_type, ["IP", "Network", "IPRange"])
 
         if host_type == "IP":
             Utils.validate_ip_address(ip_address)


### PR DESCRIPTION
- Adds argument validation to the create_ip_host() method to ensure only valid arguments of IP, Network, or IPRange are passed
- Adds the ability to replace any existing source, destination, and/or service lists when updating a local service exception ACL rule
- update version to v0.1.45. 