### PR TITLE
fix: update_acl_rule() module overwriting action from drop to accept

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.46"
+version = "0.1.47"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/admin.py
+++ b/sophosfirewall_python/admin.py
@@ -148,7 +148,9 @@ class AclRule:
                 "source_zone": source_zone,
                 "source_list": exist_sources,
                 "dest_list": exist_dests,
-                "service_list": exist_services}
+                "service_list": exist_services,
+                "action": action
+            }
 
         resp = self.client.submit_template(
             "updateserviceacl.j2", template_vars=template_vars, debug=debug


### PR DESCRIPTION
- fixed issue where update_acl_rule() was overwriting the action field from drop to accept.  Omitting the action field from the update was causing the default of accept to be used.  
- updated version to v0.1.47