### PR TITLE
feat: Add submit_xml method for posting XML as a string argument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.48"
+version = "0.1.49"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -113,6 +113,24 @@ class SophosFirewall:
         """
         return self.client.submit_template(filename, template_vars, template_dir, debug)
 
+    def submit_xml(
+        self,
+        template_data: str,
+        template_vars: dict = None,
+        set_operation: str = "add",
+        debug: bool = False,
+    ) -> dict:
+        """Submits XML payload as a string to the API. 
+        Args:
+            template_data (str): A string containing the XML payload. Variables can be optionally passed in the string using Jinja2 syntax (ex. {{ some_var }})
+            template_vars (dict, optional): Dictionary of variables to inject into the XML string. 
+            set_operation (str): Specify 'add' or 'update' set operation. Default is add. 
+
+        Returns:
+            dict
+        """
+        return self.client.submit_xml(template_data, template_vars, set_operation, debug)
+
     def remove(self, xml_tag: str, name: str, key: str = "Name", output_format: str = "dict"):
         """Remove an object from the firewall.
 


### PR DESCRIPTION
Added the `submit_xml` method which provides the ability to pass in the XML payload needed to configure a feature as an argument to the method.  The XML string can also use Jinja2 variable substitution by using `{{ variable_name }}` inside of the body.  

EXAMPLE:

```python
payload = """<MACHost>
  <Name>{{ name }}</Name>
<Description>{{ description }}</Description>
<Type>MACAddress</Type>
<MACAddress>00:16:76:49:33:CE</MACAddress>
</MACHost>"""

template_vars = {"name": "TestMacHost", "description": "Test MAC Host"}

fw.submit_xml(template_data=payload, template_vars=template_vars, debug=True)
```