### PR TITLE
FIX: Update user password lookup based on username

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.51"
+version = "0.1.52"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/authen.py
+++ b/sophosfirewall_python/authen.py
@@ -85,7 +85,7 @@ class User:
             dict: XML response converted to Python dictionary
         """
         # Get the existing user
-        resp = self.get(name=username)
+        resp = self.get(username=username)
         user_params = resp["Response"]["User"]
         user_params["Password"] = new_password
         user_params.pop("PasswordHash")


### PR DESCRIPTION
- although the argument for `update_user_password()` was `username`,  it was requiring the display name of the user to look up the user.  With this fix, it correctly takes the username.  