### PR TITLE
Fix: Provide ability to configure the XML key for object lookup when updating

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.55"
+version = "0.1.56"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/api_client.py
+++ b/sophosfirewall_python/api_client.py
@@ -335,6 +335,7 @@ class APIClient:
         xml_tag: str,
         update_params: dict,
         name: str = None,
+        lookup_key: str = "Name",
         output_format: str = "dict",
         debug: bool = False,
     ):
@@ -344,12 +345,13 @@ class APIClient:
             xml_tag (str): The XML tag indicating the type of object to be updated.
             update_params (dict): Keys/values to be updated. Keys must match an existing XML key.
             name (str, optional): The name of the object to be updated, if applicable.
+            lookup_key (str, optional): The XML key name to look up the name of the object. Default is "Name".
             output_format(str): Output format. Valid options are "dict" or "xml". Defaults to dict.
             debug (bool): Displays the XML payload that was submitted
         """
         if name:
             resp = self.get_tag_with_filter(
-                xml_tag=xml_tag, key="Name", value=name, operator="="
+                xml_tag=xml_tag, key=lookup_key, value=name, operator="="
             )
         else:
             resp = self.get_tag(xml_tag=xml_tag)

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -147,6 +147,7 @@ class SophosFirewall:
         xml_tag: str,
         update_params: dict,
         name: str = None,
+        lookup_key: str = "Name",
         output_format: str = "dict",
         debug: bool = False,
     ):
@@ -156,10 +157,11 @@ class SophosFirewall:
             xml_tag (str): The XML tag indicating the type of object to be updated.
             update_params (dict): Keys/values to be updated. Keys must match an existing XML key.
             name (str, optional): The name of the object to be updated, if applicable.
+            lookup_key (str, optional): The XML key name to look up the name of the object. Default is "Name".
             output_format(str): Output format. Valid options are "dict" or "xml". Defaults to dict.
             debug (bool): Displays the XML payload that was submitted
         """
-        return self.client.update(xml_tag, update_params, name, output_format, debug)
+        return self.client.update(xml_tag, update_params, name, lookup_key, output_format, debug)
 
     # METHODS FOR OBJECT RETRIEVAL (GET)
 


### PR DESCRIPTION
- provides ability to configure the `lookup_key` when doing an update for situations where the object doesn't have a `Name` key.  For example, for snmpv3user,  the key is `UserName`.   