### PR TITLE
Fix: Submit XML method update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.56"
+version = "0.1.57"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/api_client.py
+++ b/sophosfirewall_python/api_client.py
@@ -195,7 +195,7 @@ class APIClient:
         Args:
             template_data (str): A string containing the XML payload. Variables can be optionally passed in the string using Jinja2 (ex. {{ some_var }})
             template_vars (dict, optional): Dictionary of variables to inject into the XML string. 
-            set_operation (str): Specify 'add' or 'update' set operation. Default is add. 
+            set_operation (str): Specify 'add' or 'update' set operation. Default is add. Specify None to exclude the set operation XML block.
 
         Returns:
             dict
@@ -215,9 +215,13 @@ class APIClient:
                     <Username>{self.username}</Username>
                     <Password>{self.password}</Password>
                 </Login>
+            {{% if set_operation %}}
             <Set operation="{set_operation}">
+            {{% endif %}}
                 {template_data}
+            {{% if set_operation %}}
             </Set>
+            {{% endif %}}
             </Request>
         """
         template = environment.from_string(template_string)


### PR DESCRIPTION
- minor fix to allow exclusion of the `set operation` in the XML payload of the `submit_xml` method.  This is to solve a specific problem where the `remove` method doesn't work because the content to be removed is nested deeper than the first level.  With this fix, the `set_operation` argument can be set to None so that the set operation is excluded from the XML payload.  Then the payload of the object to be removed can be included, for example


 ```
payload = '''
<Remove>
        <AuthenticationServers>
            <RADIUSServer>
                <ServerName>{{ name }}</ServerName>
            </RADIUSServer>
        </AuthenticationServers>
    </Remove
'''

fw.submit_xml(template_data=payload, template_vars=template_vars, set_operation=None)

```


