### PR TITLE
Fix: Regression bug in submit_xml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.57"
+version = "0.1.58"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/api_client.py
+++ b/sophosfirewall_python/api_client.py
@@ -216,7 +216,7 @@ class APIClient:
                     <Password>{self.password}</Password>
                 </Login>
             {{% if set_operation %}}
-            <Set operation="{set_operation}">
+            <Set operation="{{{{ set_operation }}}}">
             {{% endif %}}
                 {template_data}
             {{% if set_operation %}}
@@ -224,6 +224,7 @@ class APIClient:
             {{% endif %}}
             </Request>
         """
+        template_vars["set_operation"] = set_operation
         template = environment.from_string(template_string)
         payload = template.render(**template_vars)
         if debug:


### PR DESCRIPTION
- Fix regression bug introduced by last PR in `submit_xml`.  XML payload was incorrectly rendered by Jinja, causing API failure. 