### PR TITLE
FIX: Allow `Any` as src/dest in firewall rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.62"
+version = "0.1.63"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/templates/createfwrule.j2
+++ b/sophosfirewall_python/templates/createfwrule.j2
@@ -27,14 +27,14 @@
             <LogTraffic>{{ log }}</LogTraffic>
             {% endif %}
             <SkipLocalDestined>Disable</SkipLocalDestined>
-            {% if src_zones %}
+            {% if src_zones and not 'Any' in src_zones %}
             <SourceZones>
                 {% for zone in src_zones %}
                 <Zone>{{ zone }}</Zone>
                 {% endfor %}
             </SourceZones>
             {% endif %}
-            {% if dst_zones %}
+            {% if dst_zones and not 'Any' in dst_zones %}
             <DestinationZones>
                 {% for zone in dst_zones %}
                 <Zone>{{ zone }}</Zone>
@@ -42,21 +42,27 @@
             </DestinationZones>
             {% endif %}
             <Schedule>All The Time</Schedule>
+            {% if src_networks and not 'Any' in src_networks %}
             <SourceNetworks>
                 {% for network in src_networks %}
                 <Network>{{ network }}</Network>
                 {% endfor %}
             </SourceNetworks>
+            {% endif %}
+            {% if dst_networks and not 'Any' in dst_networks %}
             <DestinationNetworks>
                 {% for network in dst_networks %}
                 <Network>{{ network }}</Network>
                 {% endfor %}
             </DestinationNetworks>
+            {% endif %}
+            {% if service_list and not 'Any' in service_list %}
             <Services>
                 {% for service in service_list %}
                 <Service>{{ service }}</Service>
                 {% endfor %}
             </Services>
+            {% endif %}
         </NetworkPolicy>
       </FirewallRule>
     </Set>

--- a/sophosfirewall_python/templates/updatefwrule.j2
+++ b/sophosfirewall_python/templates/updatefwrule.j2
@@ -25,14 +25,14 @@
             <Action>{{ action }}</Action>
             <LogTraffic>{{ log }}</LogTraffic>
             <SkipLocalDestined>Disable</SkipLocalDestined>
-            {% if src_zones %}
+            {% if src_zones and not 'Any' in src_zones %}
             <SourceZones>
                 {% for zone in src_zones %}
                 <Zone>{{ zone }}</Zone>
                 {% endfor %}
             </SourceZones>
             {% endif %}
-            {% if dst_zones %}
+            {% if dst_zones and not 'Any' in dst_zones %}
             <DestinationZones>
                 {% for zone in dst_zones %}
                 <Zone>{{ zone }}</Zone>
@@ -40,21 +40,27 @@
             </DestinationZones>
             {% endif %}
             <Schedule>All The Time</Schedule>
+            {% if src_networks and not 'Any' in src_networks %}
             <SourceNetworks>
                 {% for network in src_networks %}
                 <Network>{{ network }}</Network>
                 {% endfor %}
             </SourceNetworks>
+            {% endif %}
+            {% if dst_networks and not 'Any' in dst_networks %}
             <DestinationNetworks>
                 {% for network in dst_networks %}
                 <Network>{{ network }}</Network>
                 {% endfor %}
             </DestinationNetworks>
+            {% endif %}
+            {% if service_list and not 'Any' in service_list %}
             <Services>
                 {% for service in service_list %}
                 <Service>{{ service }}</Service>
                 {% endfor %}
             </Services>
+            {% endif %}
         </NetworkPolicy>
       </FirewallRule>
     </Set>


### PR DESCRIPTION
Previously,  when using `create_rule()` and `update_rule()` methods, it was not possible to specify `Any` for src/dest zone, network, or service.  Instead, you had to omit the parameters altogether, or specify an empty list to indicate `Any`.  To reduce the likelihood of errors, in this version it is now possible to specify `['Any']`.  For example:

```python
rule_params = rule_params = dict(
    rulename="ALLOW ALL - DELETE ME",
    position="Bottom",
    description="Allows everything!",
    action="Accept",
    log="Enable",
    src_zones=["Any"],
    dst_zones=["Any"],
    src_networks=["Any"],
    dst_networks=["Any"],
    service_list=["Any"]
)
resp = fw.create_rule(rule_params=rule_params)
```
