### PR TITLE
feat: Manage WebFilter Policies and User Activities

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -18,7 +18,7 @@ jobs:
           sphinx-build docs _build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.63"
+version = "0.1.64"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -38,6 +38,7 @@ from sophosfirewall_python.ips import IPS
 from sophosfirewall_python.system import Syslog, NotificationList
 from sophosfirewall_python.backup import Backup
 from sophosfirewall_python.reports import Retention
+from sophosfirewall_python.web import WebFilterPolicy, UserActivity
 
 urllib3.disable_warnings()
 
@@ -454,6 +455,22 @@ class SophosFirewall:
             dict: XML response converted to Python dictionary
         """
         return Service(self.client).get(name, operator, dst_proto, dst_port)
+
+    def get_webfilterpolicy(self, name: str = None):
+        """Get Web Filter Policy object(s)
+
+        Args:
+            name (str, optional): Web Filter Policy name. Returns all objects if not specified.
+        """
+        return WebFilterPolicy(self.client).get(name)
+
+    def get_useractivity(self, name: str = None):
+        """Get User Activity object(s)
+
+        Args:
+            name (str, optional): User Activity name. Returns all objects if not specified.
+        """
+        return UserActivity(self.client).get(name)
 
     # METHODS FOR OBJECT CREATION
 
@@ -878,6 +895,87 @@ class SophosFirewall:
         """
         return Zone(self.client).create(
             name=name, zone_type=zone_type, zone_params=zone_params, debug=debug
+        )
+    
+    def create_webfilterpolicy(self, name, default_action, download_file_size_restriction='0',
+                                 enable_reporting="Enable", download_file_size_restriction_enabled='0',
+                                 goog_app_domain_list=None, goog_app_domain_list_enabled='0',
+                                 youtube_filter_is_strict='0', youtube_filter_enabled='0',
+                                 enforce_safe_search='0', enforce_image_licensing='0',
+                                 xff_enabled='0', office_365_tenants_list=None,
+                                 office_365_directory_id=None, office_365_enabled='0',
+                                 quota_limit=60, description=None, rules=None, debug: bool = False):
+        """Create a Web Filter Policy
+
+        Args:
+            name (str): Specify a name for the Web Filter Policy. Max 50 chars.
+            default_action (str): Default action of the policy ('Allow' or 'Deny').
+            download_file_size_restriction (int): Specify maximum allowed file download size in MB (0-1536).
+            enable_reporting (str, optional): Select to enable reporting of policy. Defaults to "Enable". (API Default: Enable)
+            download_file_size_restriction_enabled (str, optional): Enable ('1') or disable ('0') checking for maximum allowed file download size. Defaults to None.
+            goog_app_domain_list (str, optional): Comma-separated list of domains allowed to access Google services. Max 256 chars. Defaults to None.
+            goog_app_domain_list_enabled (str, optional): Enable ('1') or disable ('0') specifying domains for Google services. Defaults to None.
+            youtube_filter_is_strict (str, optional): Adjust the policy used for YouTube Restricted Mode ('1' for strict, '0' for moderate). Defaults to None.
+            youtube_filter_enabled (str, optional): Enable ('1') or disable ('0') YouTube Restricted Mode. Defaults to None.
+            enforce_safe_search (str, optional): Enable ('1') or disable ('0') blocking of pornography and explicit content in search results. Defaults to None.
+            enforce_image_licensing (str, optional): Enable ('1') or disable ('0') limiting search results to Creative Commons licensed images. Defaults to None.
+            xff_enabled (str, optional): Enable ('1') or disable ('0') X-Forwarded-For header. Defaults to None.
+            office_365_tenants_list (str, optional): Comma-separated list of domain names and domain IDs allowed to access Microsoft 365. Max 4096 chars. Defaults to None.
+            office_365_directory_id (str, optional): Domain ID allowed to access the Microsoft 365 service. Max 50 chars. Defaults to None.
+            office_365_enabled (str, optional): Turn on ('1') or off ('0') specifying domains/IDs for Microsoft 365. Defaults to None.
+            quota_limit (int, optional): Maximum allowed time (1-1440 minutes) for browsing restricted web content under quota policy action. Defaults to 60. (API Default: 60)
+            description (str, optional): Specify Policy description. Max 255 chars. Defaults to None.
+            rules (list of dict, optional): Specify the rules contained in this policy. Defaults to None. See rule list structure below:
+                - categories (list of dict): List of rule categories containing:
+                    - id (str): Category Name
+                    - type (str): Category type. Valid types are 'WebCategory', 'FileType', 'URLGroup', or 'UserActivity'.
+                - http_action (str, optional): HTTP action (Allow/Deny). Defaults to Deny.
+                - https_action (str, optional): HTTPS action (Allow/Deny). Defaults to Deny.
+                - follow_http_action (str, optional): '1' to enable, '0' to disable. Defaults to 1.
+                - schedule (str, optional): Schedule name. Defaults to 'All The Time'
+                - policy_rule_enabled (str, optional): '1' to enable, '0' to disable. Defaults to 1.
+                - ccl_rule_enabled (str, optional): '1' to enable, '0' to disable. Defaults to 0.
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        return WebFilterPolicy(self.client).create(
+            name=name,
+            default_action=default_action,
+            enable_reporting=enable_reporting,
+            download_file_size_restriction=download_file_size_restriction,
+            download_file_size_restriction_enabled=download_file_size_restriction_enabled,
+            goog_app_domain_list=goog_app_domain_list,
+            goog_app_domain_list_enabled=goog_app_domain_list_enabled,
+            youtube_filter_is_strict=youtube_filter_is_strict,
+            youtube_filter_enabled=youtube_filter_enabled,
+            enforce_safe_search=enforce_safe_search,
+            enforce_image_licensing=enforce_image_licensing,
+            xff_enabled=xff_enabled,
+            office_365_tenants_list=office_365_tenants_list,
+            office_365_directory_id=office_365_directory_id,
+            office_365_enabled=office_365_enabled,
+            quota_limit=quota_limit,
+            description=description,
+            rules=rules,
+            debug=debug
+        )
+    
+    def create_useractivity(
+        self,name: str, description: str = None, category_list: list[dict] = None, debug: bool = False):
+        """Create a User Activity object
+
+        Args:
+            name (str): Specify a name for the User Activity. Max 50 chars.
+            description (str, optional): Specify a description for the User Activity. Defaults to None.
+            category_list (list of dict, optional): List of categories to apply to this User Activity. Defaults to None.
+                - id (str): Category Name
+                - type (str): Category type. Supports 'web category', 'file type', or 'url group'.
+
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        return UserActivity(self.client).create(
+            name=name, description=description, category_list=category_list, debug=debug
         )
 
     def update_user_password(
@@ -1377,6 +1475,71 @@ class SophosFirewall:
         """
         return Zone(self.client).update(name, zone_params, debug)
 
+    def update_webfilterpolicy(self, name, default_action=None, download_file_size_restriction='0',
+                                 enable_reporting="Enable", download_file_size_restriction_enabled='0',
+                                 goog_app_domain_list=None, goog_app_domain_list_enabled='0',
+                                 youtube_filter_is_strict='0', youtube_filter_enabled='0',
+                                 enforce_safe_search='0', enforce_image_licensing='0',
+                                 xff_enabled='0', office_365_tenants_list=None,
+                                 office_365_directory_id=None, office_365_enabled='0',
+                                 quota_limit=60, description=None, rules=None, rule_action="add", debug: bool = False):
+        """Update a Web Filter Policy
+
+        Args:
+            name (str): Specify a name for the Web Filter Policy. Max 50 chars. (Mandatory for identification)
+            default_action (str, optional): Default action of the policy ('Allow' or 'Deny').
+            enable_reporting (str, optional): Select to enable reporting of policy.
+            download_file_size_restriction (int, optional): Specify maximum allowed file download size in MB (0-1536).
+            download_file_size_restriction_enabled (str, optional): Enable ('1') or disable ('0') checking for maximum allowed file download size.
+            goog_app_domain_list (str, optional): Comma-separated list of domains allowed to access Google services. Max 256 chars.
+            goog_app_domain_list_enabled (str, optional): Enable ('1') or disable ('0') specifying domains for Google services.
+            youtube_filter_is_strict (str, optional): Adjust the policy used for YouTube Restricted Mode ('1' for strict, '0' for moderate).
+            youtube_filter_enabled (str, optional): Enable ('1') or disable ('0') YouTube Restricted Mode.
+            enforce_safe_search (str, optional): Enable ('1') or disable ('0') blocking of pornography and explicit content in search results.
+            enforce_image_licensing (str, optional): Enable ('1') or disable ('0') limiting search results to Creative Commons licensed images.
+            xff_enabled (str, optional): Enable ('1') or disable ('0') X-Forwarded-For header.
+            office_365_tenants_list (str, optional): Comma-separated list of domain names and domain IDs allowed to access Microsoft 365. Max 4096 chars.
+            office_365_directory_id (str, optional): Domain ID allowed to access the Microsoft 365 service. Max 50 chars.
+            office_365_enabled (str, optional): Turn on ('1') or off ('0') specifying domains/IDs for Microsoft 365.
+            quota_limit (int, optional): Maximum allowed time (1-1440 minutes) for browsing restricted web content under quota policy action.
+            description (str, optional): Specify Policy description. Max 255 chars.
+            rules (list of dict, optional): Specify the rules contained in this policy. Defaults to None. See rule list structure below:
+                - categories (list of dict): List of rule categories containing:
+                    - id (str): Category Name
+                    - type (str): Category type. Valid types are 'WebCategory', 'FileType', 'URLGroup', or 'UserActivity'.
+                - http_action (str, optional): HTTP action (Allow/Deny). Defaults to Deny.
+                - https_action (str, optional): HTTPS action (Allow/Deny). Defaults to Deny.
+                - follow_http_action (str, optional): '1' to enable, '0' to disable. Defaults to 1.
+                - schedule (str, optional): Schedule name. Defaults to 'All The Time'
+                - policy_rule_enabled (str, optional): '1' to enable, '0' to disable. Defaults to 1.
+                - ccl_rule_enabled (str, optional): '1' to enable, '0' to disable. Defaults to 0.
+            rule_action (str, optional): Action for rules ('add' or 'replace'). To remove rules, use 'replace' with the new complete list. Defaults to "add".
+            
+        Returns:
+            dict: XML response converted to Python dictionary
+        """
+        return WebFilterPolicy(self.client).update(
+            name=name,
+            default_action=default_action,
+            enable_reporting=enable_reporting,
+            download_file_size_restriction=download_file_size_restriction,
+            download_file_size_restriction_enabled=download_file_size_restriction_enabled,
+            goog_app_domain_list=goog_app_domain_list,
+            goog_app_domain_list_enabled=goog_app_domain_list_enabled,
+            youtube_filter_is_strict=youtube_filter_is_strict,
+            youtube_filter_enabled=youtube_filter_enabled,
+            enforce_safe_search=enforce_safe_search,
+            enforce_image_licensing=enforce_image_licensing,
+            xff_enabled=xff_enabled,
+            office_365_tenants_list=office_365_tenants_list,
+            office_365_directory_id=office_365_directory_id,
+            office_365_enabled=office_365_enabled,
+            quota_limit=quota_limit,
+            description=description,
+            rules=rules,
+            rule_action=rule_action,
+            debug=debug
+        )
 
 # Export the error classes for backward compatibility
 __all__ = [

--- a/sophosfirewall_python/templates/createuseractivity.j2
+++ b/sophosfirewall_python/templates/createuseractivity.j2
@@ -1,0 +1,22 @@
+<Request>
+    <Login>
+        <Username>{{username}}</Username>
+        <Password>{{password}}</Password>
+    </Login>
+    <Set operation="add">
+    <UserActivity>
+		<Name>{{ name }}</Name>
+		<Desc>{{ description }}</Desc>
+        {% if category_list %}
+		<CategoryList>
+        {% for category in category_list %}
+			<Category>
+				<type>{{ category.type }}</type>
+				<ID>{{ category.id }}</ID>
+			</Category>
+			{% endfor %}
+		</CategoryList>
+        {% endif %}
+	</UserActivity>
+  </Set>
+</Request>

--- a/sophosfirewall_python/templates/createwebfilterpolicy.j2
+++ b/sophosfirewall_python/templates/createwebfilterpolicy.j2
@@ -1,0 +1,61 @@
+<Request>
+    <Login>
+        <Username>{{username}}</Username>
+        <Password>{{password}}</Password>
+    </Login>
+    <Set operation="add">
+    <WebFilterPolicy>
+        <Name>{{ name }}</Name>
+        <Description>{{ description | default('', true) }}</Description>
+        <DefaultAction>{{ default_action }}</DefaultAction>
+        <EnableReporting>{{ enable_reporting }}</EnableReporting>
+        <DownloadFileSizeRestriction>{{ download_file_size_restriction | default('', true) }}</DownloadFileSizeRestriction>
+        <DownloadFileSizeRestrictionEnabled>{{ download_file_size_restriction_enabled | default('', true) }}</DownloadFileSizeRestrictionEnabled>
+        <GoogAppDomainListEnabled>{{ goog_app_domain_list_enabled | default('', true) }}</GoogAppDomainListEnabled>
+        <GoogAppDomainList>{{ goog_app_domain_list | default('', true) }}</GoogAppDomainList>
+        <YoutubeFilterEnabled>{{ youtube_filter_enabled | default('', true) }}</YoutubeFilterEnabled>
+        <YoutubeFilterIsStrict>{{ youtube_filter_is_strict | default('', true) }}</YoutubeFilterIsStrict>
+        <EnforceSafeSearch>{{ enforce_safe_search | default('', true) }}</EnforceSafeSearch>
+        <EnforceImageLicensing>{{ enforce_image_licensing | default('', true) }}</EnforceImageLicensing>
+        <XFFEnabled>{{ xff_enabled | default('', true) }}</XFFEnabled>
+        <Office365Enabled>{{ office_365_enabled | default('', true) }}</Office365Enabled>
+        <Office365TenantsList>{{ office_365_tenants_list | default('', true) }}</Office365TenantsList>
+        <Office365DirectoryId>{{ office_365_directory_id | default('', true) }}</Office365DirectoryId>
+        <QuotaLimit>{{ quota_limit }}</QuotaLimit>
+        {% if rules %}
+        <RuleList>
+            {% for rule in rules %}
+            <Rule>
+                <CategoryList>
+                    {% for category in rule.categories %}
+                    <Category>
+                        <ID>{{ category.id }}</ID>
+                        <type>{{ category.type }}</type>
+                    </Category>
+                    {% endfor %}
+                </CategoryList>
+                <HTTPAction>{{ rule.http_action | default('Deny', true) }}</HTTPAction>
+                <HTTPSAction>{{ rule.https_action | default ('Deny', true) }}</HTTPSAction>
+                <FollowHTTPAction>{{ rule.follow_http_action | default('1', true) }}</FollowHTTPAction>
+                <ExceptionList>
+                    <FileTypeCategory/>
+                </ExceptionList>
+                <Schedule>{{ rule.schedule | default('All The Time') }}</Schedule>
+                <PolicyRuleEnabled>{{ rule.policy_rule_enabled | default("1", true) }}</PolicyRuleEnabled>
+                <CCLRuleEnabled>{{ rule.ccl_rule_enabled | default("0", true) }}</CCLRuleEnabled>
+                {% if rule.user_list %}
+                <UserList>
+                    {% for user in rule.user_list %}
+                    <User>{{ user }}</User>
+                    {% endfor %}
+                </UserList>
+                {% endif %}
+            </Rule>
+            {% endfor %}
+        </RuleList>
+        {% else %}
+        <RuleList></RuleList>
+        {% endif %}
+    </WebFilterPolicy>
+  </Set>
+</Request>

--- a/sophosfirewall_python/templates/updatewebfilterpolicy.j2
+++ b/sophosfirewall_python/templates/updatewebfilterpolicy.j2
@@ -1,0 +1,102 @@
+<Request>
+    <Login>
+        <Username>{{username}}</Username>
+        <Password>{{password}}</Password>
+    </Login>
+    <Set operation="update">
+    <WebFilterPolicy>
+        <Name>{{ Name }}</Name> {# Assuming keys in template_vars match API casing #}
+        <Description>{{ Description | default('', true) }}</Description>
+        <DefaultAction>{{ DefaultAction | default('', true) }}</DefaultAction>
+        <EnableReporting>{{ EnableReporting | default('', true) }}</EnableReporting>
+        <DownloadFileSizeRestriction>{{ DownloadFileSizeRestriction | default('', true) }}</DownloadFileSizeRestriction>
+        <DownloadFileSizeRestrictionEnabled>{{ DownloadFileSizeRestrictionEnabled | default('', true) }}</DownloadFileSizeRestrictionEnabled>
+        <GoogAppDomainListEnabled>{{ GoogAppDomainListEnabled | default('', true) }}</GoogAppDomainListEnabled>
+        <GoogAppDomainList>{{ GoogAppDomainList | default('', true) }}</GoogAppDomainList>
+        <YoutubeFilterEnabled>{{ YoutubeFilterEnabled | default('', true) }}</YoutubeFilterEnabled>
+        <YoutubeFilterIsStrict>{{ YoutubeFilterIsStrict | default('', true) }}</YoutubeFilterIsStrict>
+        <EnforceSafeSearch>{{ EnforceSafeSearch | default('', true) }}</EnforceSafeSearch>
+        <EnforceImageLicensing>{{ EnforceImageLicensing | default('', true) }}</EnforceImageLicensing>
+        <XFFEnabled>{{ XFFEnabled | default('', true) }}</XFFEnabled>
+        <Office365Enabled>{{ Office365Enabled | default('', true) }}</Office365Enabled>
+        <Office365TenantsList>{{ Office365TenantsList | default('', true) }}</Office365TenantsList>
+        <Office365DirectoryId>{{ Office365DirectoryId | default('', true) }}</Office365DirectoryId>
+        <QuotaLimit>{{ QuotaLimit | default('', true) }}</QuotaLimit>
+        {# RuleList is handled by Python logic preparing the full list #}
+        {% if RuleList %}
+        <RuleList>
+            {% for rule in RuleList.Rule %}
+                {% if rule.CategoryList %}
+                <Rule>
+                    <CategoryList>
+                        {% if rule.CategoryList.Category is mapping %}
+                        <Category>
+                            <ID>{{ rule.CategoryList.Category.ID }}</ID>
+                            <type>{{ rule.CategoryList.Category.type }}</type>
+                        </Category>
+                        {% else %}
+                        {% for category in rule.CategoryList.Category %}
+                        <Category>
+                            <ID>{{ category.ID }}</ID>
+                            <type>{{ category.type }}</type>
+                        </Category>
+                        {% endfor %}
+                        {% endif %}
+                    </CategoryList>
+                    <HTTPAction>{{ rule.HTTPAction }}</HTTPAction>
+                    <HTTPSAction>{{ rule.HTTPSAction }}</HTTPSAction>
+                    <FollowHTTPAction>{{ rule.FollowHTTPAction }}</FollowHTTPAction>
+                    <ExceptionList>
+                        <FileTypeCategory/>
+                    </ExceptionList>
+                    <Schedule>{{ rule.Schedule }}</Schedule>
+                    <PolicyRuleEnabled>{{ rule.PolicyRuleEnabled }}</PolicyRuleEnabled>
+                    <CCLRuleEnabled>{{ rule.CCLRuleEnabled }}</CCLRuleEnabled>
+                    {% if rule.UserList %}
+                    <UserList>
+                        {% if rule.UserList.User is string %}
+                        <User>{{ rule.UserList.User }}</User>
+                        {% else %}
+                        {% for user in rule.UserList.User %}
+                        <User>{{ user }}</User>
+                        {% endfor %}
+                        {% endif %}
+                    </UserList>
+                    {% endif %}
+                </Rule>
+                {% elif rule.CategoryList is defined and not rule.CategoryList %}
+                <Rule>
+                    <CategoryList>
+                        <Category>
+                            <ID>All web traffic</ID>
+                            <type>WebCategory</type>
+                        </Category>
+                    </CategoryList>
+                    <HTTPAction>{{ rule.HTTPAction }}</HTTPAction>
+                    <HTTPSAction>{{ rule.HTTPSAction }}</HTTPSAction>
+                    <FollowHTTPAction>{{ rule.FollowHTTPAction }}</FollowHTTPAction>
+                    <ExceptionList>
+                        <FileTypeCategory/>
+                    </ExceptionList>
+                    <Schedule>{{ rule.Schedule }}</Schedule>
+                    <PolicyRuleEnabled>{{ rule.PolicyRuleEnabled }}</PolicyRuleEnabled>
+                    <CCLRuleEnabled>{{ rule.CCLRuleEnabled }}</CCLRuleEnabled>
+                    {% if rule.UserList %}
+                    <UserList>
+                        {% if rule.UserList.User is string %}
+                        <User>{{ rule.UserList.User }}</User>
+                        {% else %}
+                        {% for user in rule.UserList.User %}
+                        <User>{{ user }}</User>
+                        {% endfor %}
+                        {% endif %}
+                    </UserList>
+                    {% endif %}
+                </Rule>
+                {% endif %}
+            {% endfor %}
+        </RuleList>
+        {% endif %}
+    </WebFilterPolicy>
+  </Set>
+</Request>

--- a/sophosfirewall_python/web.py
+++ b/sophosfirewall_python/web.py
@@ -232,7 +232,6 @@ class WebFilterPolicy:
                     "CCLRuleEnabled": rule.get("ccl_rule_enabled", "0"),
                     "UserList": {"User": rule.get("user_list", [])}
                 })        
-        print(f"rule_list: {rule_list}")
 
         if rule_list:
             if updated_policy_data.get("RuleList"):
@@ -240,8 +239,6 @@ class WebFilterPolicy:
 
             if not updated_policy_data.get("RuleList"):
                 updated_policy_data["RuleList"] = {"Rule": rule_list}
-
-        print(f"Updated policy data: {updated_policy_data}")
 
         return self.api_client.submit_template(
             filename="updatewebfilterpolicy.j2",

--- a/sophosfirewall_python/web.py
+++ b/sophosfirewall_python/web.py
@@ -1,0 +1,319 @@
+"""
+Module to manage Web configuration (Protect -> Web) on Sophos Firewall. 
+"""
+from sophosfirewall_python.api_client import SophosFirewallAPIError
+
+class WebFilterPolicy:
+    """
+    Manages Web Filter Policies
+    """
+    def __init__(self, api_client):
+        self.api_client = api_client
+        self.xml_tag = "WebFilterPolicy"
+
+        # Get categories for rules
+        resp = self.api_client.get_tag("WebFilterCategory")
+        self.categories = [category['Name'] for category in resp['Response']['WebFilterCategory']]
+        self.categories.append("All web traffic") # Add default category
+
+        # Get URL Groups
+        resp = self.api_client.get_tag("WebFilterURLGroup")
+        self.url_groups = [group['Name'] for group in resp['Response']['WebFilterURLGroup']]
+
+        # Get File Types
+        resp = self.api_client.get_tag("FileType")
+        self.file_types = [file_type['Name'] for file_type in resp['Response']['FileType']]
+
+        # Get User Activities
+        resp = self.api_client.get_tag("UserActivity")
+        self.user_activities = [activity['Name'] for activity in resp['Response']['UserActivity']]
+
+    def get(self, name=None):
+        """
+        Retrieves web filter policies.
+        If name is provided, filters by name. Otherwise, retrieves all policies.
+        """
+        if name:
+            return self.api_client.get_tag_with_filter(self.xml_tag, "Name", name, operator="=")
+        return self.api_client.get_tag(self.xml_tag)
+
+    def create(self, name, default_action, download_file_size_restriction, 
+                 enable_reporting="Enable", download_file_size_restriction_enabled=None,
+                 goog_app_domain_list=None, goog_app_domain_list_enabled=None,
+                 youtube_filter_is_strict=None, youtube_filter_enabled=None,
+                 enforce_safe_search=None, enforce_image_licensing=None,
+                 xff_enabled=None, office_365_tenants_list=None,
+                 office_365_directory_id=None, office_365_enabled=None,
+                 quota_limit=60, description=None, rules=None, debug: bool = False):
+        """
+        Creates a new web filter policy.
+
+        Args:
+            name (str): Specify a name for the Web Filter Policy. Max 50 chars.
+            default_action (str): Default action of the policy ('Allow' or 'Deny').
+            download_file_size_restriction (int): Specify maximum allowed file download size in MB (0-1536).
+            enable_reporting (str, optional): Select to enable reporting of policy. Defaults to "Enable". (API Default: Enable)
+            download_file_size_restriction_enabled (str, optional): Enable ('1') or disable ('0') checking for maximum allowed file download size. Defaults to None.
+            goog_app_domain_list (str, optional): Comma-separated list of domains allowed to access Google services. Max 256 chars. Defaults to None.
+            goog_app_domain_list_enabled (str, optional): Enable ('1') or disable ('0') specifying domains for Google services. Defaults to None.
+            youtube_filter_is_strict (str, optional): Adjust the policy used for YouTube Restricted Mode ('1' for strict, '0' for moderate). Defaults to None.
+            youtube_filter_enabled (str, optional): Enable ('1') or disable ('0') YouTube Restricted Mode. Defaults to None.
+            enforce_safe_search (str, optional): Enable ('1') or disable ('0') blocking of pornography and explicit content in search results. Defaults to None.
+            enforce_image_licensing (str, optional): Enable ('1') or disable ('0') limiting search results to Creative Commons licensed images. Defaults to None.
+            xff_enabled (str, optional): Enable ('1') or disable ('0') X-Forwarded-For header. Defaults to None.
+            office_365_tenants_list (str, optional): Comma-separated list of domain names and domain IDs allowed to access Microsoft 365. Max 4096 chars. Defaults to None.
+            office_365_directory_id (str, optional): Domain ID allowed to access the Microsoft 365 service. Max 50 chars. Defaults to None.
+            office_365_enabled (str, optional): Turn on ('1') or off ('0') specifying domains/IDs for Microsoft 365. Defaults to None.
+            quota_limit (int, optional): Maximum allowed time (1-1440 minutes) for browsing restricted web content under quota policy action. Defaults to 60. (API Default: 60)
+            description (str, optional): Specify Policy description. Max 255 chars. Defaults to None.
+            rules (list of dict, optional): Specify the rules contained in this policy. Defaults to None. See rule list structure below:
+                - categories (list of dict): List of rule categories containing:
+                    - id (str): Category Name
+                    - type (str): Category type 
+                - http_action (str, optional): HTTP action (Allow/Deny). Defaults to Deny.
+                - https_action (str, optional): HTTPS action (Allow/Deny). Defaults to Deny.
+                - follow_http_action (str, optional): '1' to enable, '0' to disable. Defaults to 1.
+                - schedule (str, optional): Schedule name. Defaults to 'All The Time'
+                - policy_rule_enabled (str, optional): '1' to enable, '0' to disable. Defaults to 1.
+                - ccl_rule_enabled (str, optional): '1' to enable, '0' to disable. Defaults to 0.
+                - user_list (list of str, optional): List of users to apply this rule to. Defaults to None.
+        """
+        # Ensure rules is a list, even if None is passed
+        if rules is None:
+            rules = []
+
+        for rule in rules:
+            if "categories" in rule:
+                for category in rule["categories"]:
+                    if category.get("type") == "WebCategory":
+                        if not category.get("id") in self.categories:
+                            raise SophosFirewallAPIError(f"Category '{category.get('id')}' is not a valid Web Filter Category.")
+                    if category.get("type") == "FileType":
+                        if not category.get("id") in self.file_types:
+                            raise SophosFirewallAPIError(f"File Type '{category.get('id')}' is not a valid File Type.")
+                    if category.get("type") == "URLGroup":
+                        if not category.get("id") in self.url_groups:
+                            raise SophosFirewallAPIError(f"URL Group '{category.get('id')}' is not a valid URL Group.")
+                    if category.get("type") == "UserActivity":
+                        if not category.get("id") in self.user_activities:
+                            raise SophosFirewallAPIError(f"User Activity '{category.get('id')}' is not a valid User Activity.")
+                    if category.get("type") not in ["WebCategory", "FileType", "URLGroup", "UserActivity"]:
+                        raise SophosFirewallAPIError(f"Category type '{category.get('type')}' is not valid. Must be 'WebCategory', 'FileType', 'URLGroup', or 'UserActivity'.")
+
+        template_vars = {
+            "name": name,
+            "default_action": default_action,
+            "enable_reporting": enable_reporting,
+            "download_file_size_restriction": download_file_size_restriction,
+            "download_file_size_restriction_enabled": download_file_size_restriction_enabled,
+            "goog_app_domain_list": goog_app_domain_list,
+            "goog_app_domain_list_enabled": goog_app_domain_list_enabled,
+            "youtube_filter_is_strict": youtube_filter_is_strict,
+            "youtube_filter_enabled": youtube_filter_enabled,
+            "enforce_safe_search": enforce_safe_search,
+            "enforce_image_licensing": enforce_image_licensing,
+            "xff_enabled": xff_enabled,
+            "office_365_tenants_list": office_365_tenants_list,
+            "office_365_directory_id": office_365_directory_id,
+            "office_365_enabled": office_365_enabled,
+            "quota_limit": quota_limit,
+            "description": description,
+            "rules": rules
+        }
+        return self.api_client.submit_template(
+            filename="createwebfilterpolicy.j2",
+            template_vars=template_vars,
+            debug=debug
+        )
+
+    def update(self, name, default_action=None, enable_reporting=None,
+                 download_file_size_restriction=None, download_file_size_restriction_enabled=None,
+                 goog_app_domain_list=None, goog_app_domain_list_enabled=None,
+                 youtube_filter_is_strict=None, youtube_filter_enabled=None,
+                 enforce_safe_search=None, enforce_image_licensing=None,
+                 xff_enabled=None, office_365_tenants_list=None,
+                 office_365_directory_id=None, office_365_enabled=None,
+                 quota_limit=None, description=None, rules=None, rule_action="add", debug: bool = False):
+        """
+        Updates an existing web filter policy.
+        Fetches the existing policy and applies changes only for provided arguments.
+        Handles 'add' or 'replace' actions for rules.
+        To remove specific rules, use rule_action='replace' with the desired final list of rules.
+        The full policy object is sent in the update payload.
+
+        Args:
+            name (str): Specify a name for the Web Filter Policy. Max 50 chars. (Mandatory for identification)
+            default_action (str, optional): Default action of the policy ('Allow' or 'Deny').
+            enable_reporting (str, optional): Select to enable reporting of policy.
+            download_file_size_restriction (int, optional): Specify maximum allowed file download size in MB (0-1536).
+            download_file_size_restriction_enabled (str, optional): Enable ('1') or disable ('0') checking for maximum allowed file download size.
+            goog_app_domain_list (str, optional): Comma-separated list of domains allowed to access Google services. Max 256 chars.
+            goog_app_domain_list_enabled (str, optional): Enable ('1') or disable ('0') specifying domains for Google services.
+            youtube_filter_is_strict (str, optional): Adjust the policy used for YouTube Restricted Mode ('1' for strict, '0' for moderate).
+            youtube_filter_enabled (str, optional): Enable ('1') or disable ('0') YouTube Restricted Mode.
+            enforce_safe_search (str, optional): Enable ('1') or disable ('0') blocking of pornography and explicit content in search results.
+            enforce_image_licensing (str, optional): Enable ('1') or disable ('0') limiting search results to Creative Commons licensed images.
+            xff_enabled (str, optional): Enable ('1') or disable ('0') X-Forwarded-For header.
+            office_365_tenants_list (str, optional): Comma-separated list of domain names and domain IDs allowed to access Microsoft 365. Max 4096 chars.
+            office_365_directory_id (str, optional): Domain ID allowed to access the Microsoft 365 service. Max 50 chars.
+            office_365_enabled (str, optional): Turn on ('1') or off ('0') specifying domains/IDs for Microsoft 365.
+            quota_limit (int, optional): Maximum allowed time (1-1440 minutes) for browsing restricted web content under quota policy action.
+            description (str, optional): Specify Policy description. Max 255 chars.
+            rules (list of dict, optional): Specify the rules contained in this policy. Defaults to None. See rule list structure below:
+                - categories (list of dict): List of rule categories containing:
+                    - id (str): Category Name
+                    - type (str): Category type. Valid options are 'WebCategory', 'FileType', 'URLGroup', or 'UserActivity'.
+                - http_action (str, optional): HTTP action (Allow/Deny). Defaults to Deny.
+                - https_action (str, optional): HTTPS action (Allow/Deny). Defaults to Deny.
+                - follow_http_action (str, optional): '1' to enable, '0' to disable. Defaults to 1.
+                - schedule (str, optional): Schedule name. Defaults to 'All The Time'
+                - policy_rule_enabled (str, optional): '1' to enable, '0' to disable. Defaults to 1.
+                - ccl_rule_enabled (str, optional): '1' to enable, '0' to disable. Defaults to 0.
+                - user_list (str, optional): List of users to apply this policy to. Defaults to "None".
+            rule_action (str, optional): Action for rules ('add' or 'replace'). Defaults to "add".
+        """
+        updated_policy_data = self.get(name=name)['Response'][self.xml_tag]
+
+        # Update scalar fields if new values are provided
+        if default_action is not None: updated_policy_data["DefaultAction"] = default_action
+        if enable_reporting is not None: updated_policy_data["EnableReporting"] = enable_reporting
+        if download_file_size_restriction is not None: updated_policy_data["DownloadFileSizeRestriction"] = download_file_size_restriction
+        if download_file_size_restriction_enabled is not None: updated_policy_data["DownloadFileSizeRestrictionEnabled"] = download_file_size_restriction_enabled
+        if goog_app_domain_list is not None: updated_policy_data["GoogAppDomainList"] = goog_app_domain_list
+        if goog_app_domain_list_enabled is not None: updated_policy_data["GoogAppDomainListEnabled"] = goog_app_domain_list_enabled
+        if youtube_filter_is_strict is not None: updated_policy_data["YoutubeFilterIsStrict"] = youtube_filter_is_strict
+        if youtube_filter_enabled is not None: updated_policy_data["YoutubeFilterEnabled"] = youtube_filter_enabled
+        if enforce_safe_search is not None: updated_policy_data["EnforceSafeSearch"] = enforce_safe_search
+        if enforce_image_licensing is not None: updated_policy_data["EnforceImageLicensing"] = enforce_image_licensing
+        if xff_enabled is not None: updated_policy_data["XFFEnabled"] = xff_enabled
+        if office_365_tenants_list is not None: updated_policy_data["Office365TenantsList"] = office_365_tenants_list
+        if office_365_directory_id is not None: updated_policy_data["Office365DirectoryId"] = office_365_directory_id
+        if office_365_enabled is not None: updated_policy_data["Office365Enabled"] = office_365_enabled
+        if quota_limit is not None: updated_policy_data["QuotaLimit"] = quota_limit
+        if description is not None: updated_policy_data["Description"] = description
+
+        # Rules handling
+        rule_list = []
+        if "RuleList" in updated_policy_data and not rule_action == "replace": # If we are not replacing, keep existing rules
+            if isinstance(updated_policy_data["RuleList"]["Rule"], dict):
+                rule_list = [updated_policy_data["RuleList"]["Rule"]]
+            if isinstance(updated_policy_data["RuleList"]["Rule"], list):
+                rule_list = updated_policy_data["RuleList"]["Rule"]
+
+        if rules and (rule_action == "add" or rule_action == "replace"):
+            for rule in rules:
+                category_list = []
+                for category in rule.get("categories", []):
+                    if category.get("type") == "WebCategory":
+                        if not category.get("id") in self.categories:
+                            raise SophosFirewallAPIError(f"Category '{category.get('id')}' is not a valid Web Filter Category.")
+                    if category.get("type") == "FileType":
+                        if not category.get("id") in self.file_types:
+                            raise SophosFirewallAPIError(f"File Type '{category.get('id')}' is not a valid File Type.")
+                    if category.get("type") == "URLGroup":
+                        if not category.get("id") in self.url_groups:
+                            raise SophosFirewallAPIError(f"URL Group '{category.get('id')}' is not a valid URL Group.")
+                    if category.get("type") == "UserActivity":
+                        if not category.get("id") in self.user_activities:
+                            raise SophosFirewallAPIError(f"User Activity '{category.get('id')}' is not a valid User Activity.")
+                    if category.get("type") not in ["WebCategory", "FileType", "URLGroup", "UserActivity"]:
+                        raise SophosFirewallAPIError(f"Category type '{category.get('type')}' is not valid. Must be 'WebCategory', 'FileType', 'URLGroup', or 'UserActivity'.")
+                    category_list.append({
+                        "ID": category.get("id", ""),
+                        "type": category.get("type", "")
+                    })
+                rule_list.append({
+                    "CategoryList": {"Category": category_list},
+                    "HTTPAction": rule.get("http_action", "Deny"),
+                    "HTTPSAction": rule.get("https_action", "Deny"),
+                    "FollowHTTPAction": rule.get("follow_http_action", "1"),
+                    "Schedule": rule.get("schedule", "All The Time"),
+                    "PolicyRuleEnabled": rule.get("policy_rule_enabled", "1"),
+                    "CCLRuleEnabled": rule.get("ccl_rule_enabled", "0"),
+                    "UserList": {"User": rule.get("user_list", [])}
+                })        
+        print(f"rule_list: {rule_list}")
+
+        if rule_list:
+            if updated_policy_data.get("RuleList"):
+                updated_policy_data["RuleList"]["Rule"] = rule_list
+
+            if not updated_policy_data.get("RuleList"):
+                updated_policy_data["RuleList"] = {"Rule": rule_list}
+
+        print(f"Updated policy data: {updated_policy_data}")
+
+        return self.api_client.submit_template(
+            filename="updatewebfilterpolicy.j2",
+            template_vars=updated_policy_data, 
+            debug=debug
+        )
+
+class UserActivity:
+    """
+    Manages User Activities.
+    """
+    def __init__(self, api_client):
+        self.api_client = api_client
+        self.xml_tag = "UserActivity"
+
+        # Get categories
+        resp = self.api_client.get_tag("WebFilterCategory")
+        self.categories = [category['Name'] for category in resp['Response']['WebFilterCategory']]
+        self.categories.append("All web traffic") # Add default category
+
+        # Get URL Groups
+        resp = self.api_client.get_tag("WebFilterURLGroup")
+        self.url_groups = [group['Name'] for group in resp['Response']['WebFilterURLGroup']]
+
+        # Get File Types
+        resp = self.api_client.get_tag("FileType")
+        self.file_types = [file_type['Name'] for file_type in resp['Response']['FileType']]
+
+        
+    def get(self, name=None):
+        """
+        Retrieves User Activities.
+        If name is provided, filters by name. Otherwise, retrieves all policies.
+        """
+        if name:
+            return self.api_client.get_tag_with_filter(self.xml_tag, "Name", name, operator="=")
+        return self.api_client.get_tag(self.xml_tag)
+
+    def create(self, name, description: str=None, category_list: list[dict]=None, debug: bool = False):
+        """
+        Creates a new User Activity.
+
+        Args:
+            name (str): Specify a name for the User Activity. Max 50 chars.
+            description (str, optional): Specify a description for the User Activity. Defaults to None.
+            category_list (list of dict, optional): List of categories to apply to this User Activity. Defaults to None.
+                - id (str): Category Name
+                - type (str): Category type. Supports 'web category', 'file type', or 'url group'.
+        """
+
+        if category_list:
+            for category in category_list:
+                if category.get("type") == "web category":
+                    if not category.get("id") in self.categories:
+                        raise SophosFirewallAPIError(f"Category '{category.get('id')}' is not a valid Web Filter Category.")
+                if category.get("type") == "file type":
+                    if not category.get("id") in self.file_types:
+                        raise SophosFirewallAPIError(f"File Type '{category.get('id')}' is not a valid File Type.")
+                if category.get("type") == "url group":
+                    if not category.get("id") in self.url_groups:
+                        raise SophosFirewallAPIError(f"URL Group '{category.get('id')}' is not a valid URL Group.")
+                if category.get("type") not in ["web category", "file type", "url group"]:
+                    raise SophosFirewallAPIError(f"Category type '{category.get('type')}' is not valid. Must be 'web category', 'file type', or 'url group'.")
+       
+        template_vars = {
+            "name": name,
+            "description": description,
+            "category_list": category_list if category_list else []
+        }
+
+        return self.api_client.submit_template(
+            filename="createuseractivity.j2",
+            template_vars=template_vars,
+            debug=debug
+        )


### PR DESCRIPTION
Provide ability to manage WebFilter Policies and User Activities as mentioned in Issue [94](https://github.com/sophos/sophos-firewall-sdk/issues/94)

## Setup
```python
from sophosfirewall_python.firewallapi import SophosFirewall, SophosFirewallZeroRecords
fw = SophosFirewall(username, password, "testfirewall.sophos.net", port=4444, verify=False)
```

## Listing and retrieving existing Web Policies
```python
# View all policies
fw.get_webfilterpolicy()

# View a single policy by name
fw.get_webfilterpolicy(name='MyPolicy')
```

## Creating, modifying, and deleting Web Policies
### Creating
```python
# Define the rules. Many other available settings here, keeping it simple and using defaults. 
  rules = [
  {
    "categories": [
      {
        "id": "Extreme",
        "type": "WebCategory"
      }
    ],
    "http_action": "Deny"
  },
  {
    "categories": [
      {
        "id": "All web traffic",
        "type": "WebCategory"
      }
    ],
    "http_action": "Allow"
  }
]
# Create the policy
fw.create_webfilterpolicy(name="MyPolicy", default_action="Deny", description="test policy", rules=rules)

# Another example with a rule having > 1 category and assigned to a group
rules = [
    {
        "categories": [
            {
                "id": "Militancy & Extremist",
                "type": "WebCategory"
            },
            {
                "id": "Extreme",
                "type": "WebCategory"
            }
        ],
        "http_action": "Deny",
        "https_action": "Deny",
        "user_list": [
            "Guest Group"
        ]
    }
]

fw.create_webfilterpolicy(name="MyPolicy2", default_action="Deny", description="test policy", rules=rules)
```
### Modifying
Any of the policy settings can be modified, however for rules we can only support `add` and `replace` options. This is because the individual rules do not have any single identifier such as a name.  To match a rule for modify or delete operations would be difficult due to the numerous settings in each rule that would have to match exactly to the input provided by the `rules` argument.  If an individual rule needs to be modified, to work around this would require defining all of the rules that are needed in the policy in the `rules` argument and then use `rule_action='replace'`.  

```python
# Modify the description of a policy
fw.update_webfilterpolicy(name="MyPolicy", default_action="Deny", description="Updated description")

# Add a rule to the policy (default action is add)
rules = [{"categories": [{"id": "Advertisements", "type": "WebCategory"}], "http_action": "Deny"}]
fw.update_webfilterpolicy(name="MyPolicy", default_action="Deny", rules=rules)

# Replace the rules on a policy
rules = [{"categories": [{"id": "Militancy & Extremist", "type": "WebCategory"}, {"id": "Extreme", "type": "WebCategory"}], "http_action": "Deny", "https_action": "Deny"}]

fw.update_webfilterpolicy(name="MyPolicy", default_action="Deny", rule_action="replace", rules=rules)
```
### Deleting
We can use the generic `remove` method.  
```python
fw.remove(fw.remove(xml_tag="WebFilterPolicy", name="MyPolicy")
```
## Creating custom User Activities (e.g., specific categories or URL groups)
The new functionality included with this PR is creation of User Activities. Management of URL Groups is already available using `create_urlgroup()` and `update_urlgroup`.  We have not addressed creating custom Categories in this PR. 

### Creating
```python
# Define the categories
categories = [{"id": "Extreme", "type": "web category"}, {"id": "Local TLS exclusion list", "type": "url group"}, {"id": "Aud
 io Files", "type": "file type"}]

# Create the User Activity
fw.create_useractivity(name="MyUserActivity", description="Custom User Activity", category_list=categories)
```
## Assigning User Activities to Web Policies or directly to specific users
```python
# Assign custom User Activity to Web Policy
rules = [{"categories": [{"id": "MyUserActivity", "type": "UserActivity"}], "https_action": "Deny", "http_action": "Deny"}]

fw.create_webfilterpolicy(name="MyPolicyWithCustomUserActivity", default_action="Deny", rules=rules)

# Assign custom User Activity to Web Policy with specific user
rules = [{"categories": [{"id": "MyUserActivity", "type": "UserActivity"}], "https_action": "Deny", "http_action": "Deny", "user_list": ["testuser"]}]

fw.create_webfilterpolicy(name="MyPolicyWithUserAssignedActivity", default_action="Deny", rules=rules)
```
## Retrieving existing User Activities for audit purposes
```python
# Get all User Activities
fw.get_useractivity()

# Get specific User Activity
fw.get_useractivity(name='MyUserActivity')
