### PR TITLE
FEAT: added additional arguments for create/update firewall rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.64"
+version = "0.1.65"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/firewallapi.py
+++ b/sophosfirewall_python/firewallapi.py
@@ -609,6 +609,27 @@ class SophosFirewall:
             src_networks(list): Name(s) of the source network(s)
             dst_networks(list): Name(s) of the destination network(s)
             service_list(list): Name(s) of service(s)
+            web_filter(str): Name of the web filter policy to apply
+            web_category_traffic_shaping(str): Name of the web category traffic shaping policy to apply
+            block_quic(str): Enable/Disable QUIC blocking
+            scan_virus(str): Enable/Disable virus scanning
+            proxy_mode(str): Enable/Disable proxy mode
+            decrypt_https(str): Enable/Disable HTTPS decryption
+            source_security_heartbeat(str): Enable/Disable source security heartbeat
+            minimum_source_hb_permitted(str): Minimum source heartbeat permitted
+            dest_security_heartbeat(str): Enable/Disable destination security heartbeat
+            minimum_dest_hb_permitted(str): Minimum destination heartbeat permitted
+            application_control(str): Enable/Disable application control
+            application_base_qos_policy(str): Name of the application base QoS policy to apply
+            intrusion_prevention(str): Enable/Disable intrusion prevention
+            qos_policy(str): Name of the QoS traffic shaping policy to apply
+            dscp_marking(str): DSCP marking value
+            scan_smtp(str): Enable/Disable SMTP scanning
+            scan_smtps(str): Enable/Disable SMTPS scanning
+            scan_imap(str): Enable/Disable IMAP scanning
+            scan_imaps(str): Enable/Disable IMAPS scanning
+            scan_pop3(str): Enable/Disable POP3 scanning
+            scan_pop3s(str): Enable/Disable POP3S scanning
         Returns:
             dict: XML response converted to Python dictionary
         """
@@ -1281,6 +1302,27 @@ class SophosFirewall:
             src_networks(list): Name(s) of the source network(s)
             dst_networks(list): Name(s) of the destination network(s)
             service_list(list): Name(s) of service(s)
+            web_filter(str): Name of the web filter policy to apply
+            web_category_traffic_shaping(str): Name of the web category traffic shaping policy to apply
+            block_quic(str): Enable/Disable QUIC blocking
+            scan_virus(str): Enable/Disable virus scanning
+            proxy_mode(str): Enable/Disable proxy mode
+            decrypt_https(str): Enable/Disable HTTPS decryption
+            source_security_heartbeat(str): Enable/Disable source security heartbeat
+            minimum_source_hb_permitted(str): Minimum source heartbeat permitted
+            dest_security_heartbeat(str): Enable/Disable destination security heartbeat
+            minimum_dest_hb_permitted(str): Minimum destination heartbeat permitted
+            application_control(str): Enable/Disable application control
+            application_base_qos_policy(str): Name of the application base QoS policy to apply
+            intrusion_prevention(str): Enable/Disable intrusion prevention
+            qos_policy(str): Name of the QoS traffic shaping policy to apply
+            dscp_marking(str): DSCP marking value
+            scan_smtp(str): Enable/Disable SMTP scanning
+            scan_smtps(str): Enable/Disable SMTPS scanning
+            scan_imap(str): Enable/Disable IMAP scanning
+            scan_imaps(str): Enable/Disable IMAPS scanning
+            scan_pop3(str): Enable/Disable POP3 scanning
+            scan_pop3s(str): Enable/Disable POP3S scanning
         Returns:
             dict: XML response converted to Python dictionary
         """

--- a/sophosfirewall_python/firewallrule.py
+++ b/sophosfirewall_python/firewallrule.py
@@ -47,6 +47,28 @@ class FirewallRule:
             src_networks(list): Name(s) of the source network(s)
             dst_networks(list): Name(s) of the destination network(s)
             service_list(list): Name(s) of service(s)
+            web_filter(str): Name of the web filter policy to apply
+            web_category_traffic_shaping(str): Name of the web category traffic shaping policy to apply
+            block_quic(str): Enable/Disable QUIC blocking
+            scan_virus(str): Enable/Disable virus scanning
+            proxy_mode(str): Enable/Disable proxy mode
+            decrypt_https(str): Enable/Disable HTTPS decryption
+            source_security_heartbeat(str): Enable/Disable source security heartbeat
+            minimum_source_hb_permitted(str): Minimum source heartbeat permitted
+            dest_security_heartbeat(str): Enable/Disable destination security heartbeat
+            minimum_dest_hb_permitted(str): Minimum destination heartbeat permitted
+            application_control(str): Enable/Disable application control
+            application_base_qos_policy(str): Name of the application base QoS policy to apply
+            intrusion_prevention(str): Enable/Disable intrusion prevention
+            qos_policy(str): Name of the QoS traffic shaping policy to apply
+            dscp_marking(str): DSCP marking value
+            scan_smtp(str): Enable/Disable SMTP scanning
+            scan_smtps(str): Enable/Disable SMTPS scanning
+            scan_imap(str): Enable/Disable IMAP scanning
+            scan_imaps(str): Enable/Disable IMAPS scanning
+            scan_pop3(str): Enable/Disable POP3 scanning
+            scan_pop3s(str): Enable/Disable POP3S scanning
+
         Returns:
             dict: XML response converted to Python dictionary
         """
@@ -75,6 +97,27 @@ class FirewallRule:
             src_networks(list): Name(s) of the source network(s)
             dst_networks(list): Name(s) of the destination network(s)
             service_list(list): Name(s) of service(s)
+            web_filter(str): Name of the web filter policy to apply
+            web_category_traffic_shaping(str): Name of the web category traffic shaping policy to apply
+            block_quic(str): Enable/Disable QUIC blocking
+            scan_virus(str): Enable/Disable virus scanning
+            proxy_mode(str): Enable/Disable proxy mode
+            decrypt_https(str): Enable/Disable HTTPS decryption
+            source_security_heartbeat(str): Enable/Disable source security heartbeat
+            minimum_source_hb_permitted(str): Minimum source heartbeat permitted
+            dest_security_heartbeat(str): Enable/Disable destination security heartbeat
+            minimum_dest_hb_permitted(str): Minimum destination heartbeat permitted
+            application_control(str): Enable/Disable application control
+            application_base_qos_policy(str): Name of the application base QoS policy to apply
+            intrusion_prevention(str): Enable/Disable intrusion prevention
+            qos_policy(str): Name of the QoS traffic shaping policy to apply
+            dscp_marking(str): DSCP marking value
+            scan_smtp(str): Enable/Disable SMTP scanning
+            scan_smtps(str): Enable/Disable SMTPS scanning
+            scan_imap(str): Enable/Disable IMAP scanning
+            scan_imaps(str): Enable/Disable IMAPS scanning
+            scan_pop3(str): Enable/Disable POP3 scanning
+            scan_pop3s(str): Enable/Disable POP3S scanning
         Returns:
             dict: XML response converted to Python dictionary
         """
@@ -153,4 +196,32 @@ class FirewallRule:
         resp = self.client.submit_template(
             "updatefwrule.j2", template_vars=updated_rule_params, debug=debug
         )
+
+        params = [
+            "web_filter",
+            "web_category_traffic_shaping",
+            "block_quic",
+            "scan_virus",
+            "proxy_mode",
+            "decrypt_https",
+            "source_security_heartbeat",
+            "minimum_source_hb_permitted",
+            "dest_security_heartbeat",
+            "minimum_dest_hb_permitted",
+            "application_control",
+            "application_base_qos_policy",
+            "intrusion_prevention",
+            "qos_policy",
+            "dscp_marking",
+            "scan_smtp",
+            "scan_smtps",
+            "scan_imap",
+            "scan_imaps",
+            "scan_pop3",
+            "scan_pop3s"
+        ]
+        for param in params:
+            if param in rule_params:
+                updated_rule_params[param] = rule_params[param]
+
         return resp

--- a/sophosfirewall_python/templates/createfwrule.j2
+++ b/sophosfirewall_python/templates/createfwrule.j2
@@ -9,7 +9,7 @@
         <Description>{{ description if description else '' }}</Description>
         <IPFamily>IPv4</IPFamily>
         <Status>{{ status }}</Status>
-        <Position>{{ position }}</Position>
+        <Position>{{ position if position else 'Bottom'}}</Position>
         <PolicyType>Network</PolicyType>
         {% if position == 'After' %}
         <After>
@@ -62,6 +62,69 @@
                 <Service>{{ service }}</Service>
                 {% endfor %}
             </Services>
+            {% endif %}
+            {% if web_filter %}
+            <WebFilter>{{ web_filter }}</WebFilter>
+            {% endif %}
+            {% if web_category_traffic_shaping %}
+            <WebCategoryBaseQoSPolicy>{{ web_category_traffic_shaping }}</WebCategoryBaseQoSPolicy>
+            {% endif %}
+            {% if block_quic %}
+            <BlockQuickQuic>{{ block_quic }}</BlockQuickQuic>
+            {% endif %}
+            {% if scan_virus %}
+            <ScanVirus>{{ scan_virus }}</ScanVirus>
+            {% endif %}
+            {% if proxy_mode %}
+            <ProxyMode>{{ proxy_mode }}</ProxyMode>
+            {% endif %}
+            {% if decrypt_https %}
+            <DecryptHTTPS>{{ decrypt_https }}</DecryptHTTPS>
+            {% endif %}
+            {% if source_security_heartbeat %}
+            <SourceSecurityHeartbeat>{{ source_security_heartbeat }}</SourceSecurityHeartbeat>
+            {% endif %}
+            {% if minimum_source_hb_permitted %}
+            <MinimumSourceHBPermitted>{{ minimum_source_hb_permitted }}</MinimumSourceHBPermitted>
+            {% endif %}
+            {% if dest_security_heartbeat %}
+            <DestSecurityHeartbeat>{{ dest_security_heartbeat }}</DestSecurityHeartbeat>
+            {% endif %}
+            {% if minimum_dest_hb_permitted %}
+            <MinimumDestHBPermitted>{{ minimum_dest_hb_permitted }}</MinimumDestHBPermitted>
+            {% endif %}
+            {% if application_control %}
+            <ApplicationControl>{{ application_control }}</ApplicationControl>
+            {% endif %}
+            {% if application_base_qos_policy %}
+            <ApplicationBaseQoSPolicy>{{ application_base_qos_policy }}</ApplicationBaseQoSPolicy>
+            {% endif %}
+            {% if intrusion_prevention %}
+            <IntrusionPrevention>{{ intrusion_prevention }}</IntrusionPrevention>
+            {% endif %}
+            {% if qos_policy %}
+            <TrafficShappingPolicy>{{ qos_policy }}</TrafficShappingPolicy>
+            {% endif %}
+            {% if dscp_marking %}
+            <DSCPMarking>{{ dscp_marking }}</DSCPMarking>
+            {% endif %}
+            {% if scan_smtp %}
+            <ScanSMTP>{{ scan_smtp }}</ScanSMTP>
+            {% endif %}
+            {% if scan_smtps %}
+            <ScanSMTPS>{{ scan_smtps }}</ScanSMTPS>
+            {% endif %}
+            {% if scan_imap %}
+            <ScanIMAP>{{ scan_imap }}</ScanIMAP>
+            {% endif %}
+            {% if scan_imaps %}
+            <ScanIMAPS>{{ scan_imaps }}</ScanIMAPS>
+            {% endif %}
+            {% if scan_pop3 %}
+            <ScanPOP3>{{ scan_pop3 }}</ScanPOP3>
+            {% endif %}
+            {% if scan_pop3s %}
+            <ScanPOP3S>{{ scan_pop3s }}</ScanPOP3S>
             {% endif %}
         </NetworkPolicy>
       </FirewallRule>

--- a/sophosfirewall_python/templates/updatefwrule.j2
+++ b/sophosfirewall_python/templates/updatefwrule.j2
@@ -61,6 +61,69 @@
                 {% endfor %}
             </Services>
             {% endif %}
+            {% if web_filter %}
+            <WebFilter>{{ web_filter }}</WebFilter>
+            {% endif %}
+            {% if web_category_traffic_shaping %}
+            <WebCategoryBaseQoSPolicy>{{ web_category_traffic_shaping }}</WebCategoryBaseQoSPolicy>
+            {% endif %}
+            {% if block_quic %}
+            <BlockQuickQuic>{{ block_quic }}</BlockQuickQuic>
+            {% endif %}
+            {% if scan_virus %}
+            <ScanVirus>{{ scan_virus }}</ScanVirus>
+            {% endif %}
+            {% if proxy_mode %}
+            <ProxyMode>{{ proxy_mode }}</ProxyMode>
+            {% endif %}
+            {% if decrypt_https %}
+            <DecryptHTTPS>{{ decrypt_https }}</DecryptHTTPS>
+            {% endif %}
+            {% if source_security_heartbeat %}
+            <SourceSecurityHeartbeat>{{ source_security_heartbeat }}</SourceSecurityHeartbeat>
+            {% endif %}
+            {% if minimum_source_hb_permitted %}
+            <MinimumSourceHBPermitted>{{ minimum_source_hb_permitted }}</MinimumSourceHBPermitted>
+            {% endif %}
+            {% if dest_security_heartbeat %}
+            <DestSecurityHeartbeat>{{ dest_security_heartbeat }}</DestSecurityHeartbeat>
+            {% endif %}
+            {% if minimum_dest_hb_permitted %}
+            <MinimumDestHBPermitted>{{ minimum_dest_hb_permitted }}</MinimumDestHBPermitted>
+            {% endif %}
+            {% if application_control %}
+            <ApplicationControl>{{ application_control }}</ApplicationControl>
+            {% endif %}
+            {% if application_base_qos_policy %}
+            <ApplicationBaseQoSPolicy>{{ application_base_qos_policy }}</ApplicationBaseQoSPolicy>
+            {% endif %}
+            {% if intrusion_prevention %}
+            <IntrusionPrevention>{{ intrusion_prevention }}</IntrusionPrevention>
+            {% endif %}
+            {% if qos_policy %}
+            <TrafficShappingPolicy>{{ qos_policy }}</TrafficShappingPolicy>
+            {% endif %}
+            {% if dscp_marking %}
+            <DSCPMarking>{{ dscp_marking }}</DSCPMarking>
+            {% endif %}
+            {% if scan_smtp %}
+            <ScanSMTP>{{ scan_smtp }}</ScanSMTP>
+            {% endif %}
+            {% if scan_smtps %}
+            <ScanSMTPS>{{ scan_smtps }}</ScanSMTPS>
+            {% endif %}
+            {% if scan_imap %}
+            <ScanIMAP>{{ scan_imap }}</ScanIMAP>
+            {% endif %}
+            {% if scan_imaps %}
+            <ScanIMAPS>{{ scan_imaps }}</ScanIMAPS>
+            {% endif %}
+            {% if scan_pop3 %}
+            <ScanPOP3>{{ scan_pop3 }}</ScanPOP3>
+            {% endif %}
+            {% if scan_pop3s %}
+            <ScanPOP3S>{{ scan_pop3s }}</ScanPOP3S>
+            {% endif %}
         </NetworkPolicy>
       </FirewallRule>
     </Set>

--- a/sophosfirewall_python/tests/functional.py
+++ b/sophosfirewall_python/tests/functional.py
@@ -242,11 +242,11 @@ def test_create_rule(setup):
 
     rule_params = dict(
         rulename="FUNC_TESTRULE1",
-        after_rulename="Block.green.sophos",
+        # after_rulename="Block.green.sophos",
         action="Accept",
         description="Test rule created by functional testing.",
         log="Enable",
-        src_zones=["TestLab"],
+        src_zones=["WAN"],
         dst_zones=["LAN"],
         src_networks=["FUNC_TESTNETWORK1"],
         dst_networks=["FUNC_TESTNETWORK2"],


### PR DESCRIPTION
Added support for the following arguments for creating and updating firewall rules:

            web_filter(str): Name of the web filter policy to apply
            web_category_traffic_shaping(str): Name of the web category traffic shaping policy to apply
            block_quic(str): Enable/Disable QUIC blocking
            scan_virus(str): Enable/Disable virus scanning
            proxy_mode(str): Enable/Disable proxy mode
            decrypt_https(str): Enable/Disable HTTPS decryption
            source_security_heartbeat(str): Enable/Disable source security heartbeat
            minimum_source_hb_permitted(str): Minimum source heartbeat permitted
            dest_security_heartbeat(str): Enable/Disable destination security heartbeat
            minimum_dest_hb_permitted(str): Minimum destination heartbeat permitted
            application_control(str): Enable/Disable application control
            application_base_qos_policy(str): Name of the application base QoS policy to apply
            intrusion_prevention(str): Enable/Disable intrusion prevention
            qos_policy(str): Name of the QoS traffic shaping policy to apply
            dscp_marking(str): DSCP marking value
            scan_smtp(str): Enable/Disable SMTP scanning
            scan_smtps(str): Enable/Disable SMTPS scanning
            scan_imap(str): Enable/Disable IMAP scanning
            scan_imaps(str): Enable/Disable IMAPS scanning
            scan_pop3(str): Enable/Disable POP3 scanning
            scan_pop3s(str): Enable/Disable POP3S scanning