### PR TITLE
fix: the DisconnectLiveUser option no longer exists in sfos v22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sophosfirewall-python"
 packages = [
     { include = "sophosfirewall_python" },
 ]
-version = "0.1.65"
+version = "0.1.66"
 description = "Python SDK for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophosfirewall_python/profile.py
+++ b/sophosfirewall_python/profile.py
@@ -215,7 +215,7 @@ class AdminProfile:
             "other_guest_user_settings": kwargs.get("other_guest_user_settings", exist_profile["Identity"]["OtherGuestUserSettings"]),
             "policy": kwargs.get("policy", exist_profile["Identity"]["Policy"]),
             "test_external_server_connectivity": kwargs.get("test_external_server_connectivity", exist_profile["Identity"]["TestExternalServerConnectivity"]),
-            "disconnect_live_user": kwargs.get("disconnect_live_user", exist_profile["Identity"]["DisconnectLiveUser"]),
+            "disconnect_live_user": kwargs.get("disconnect_live_user", exist_profile["Identity"].get("DisconnectLiveUser")),
             "firewall": kwargs.get("network", exist_profile["Firewall"]),
             "set_vpn_profile": kwargs.get("set_vpn_profile"),
             "connect_tunnel": kwargs.get("connect_tunnel", exist_profile["VPN"]["ConnectTunnel"]),


### PR DESCRIPTION
In sfos v22, Administration Profiles no longer have the Disconnect Live User option.  This resulted in a KeyError on DiconnectLiveUser when trying to create or update a profile. 