### PR TITLE
Fix : TypeError in submit_xml when zero records are returned

### DIFF
--- a/sophosfirewall_python/api_client.py
+++ b/sophosfirewall_python/api_client.py
@@ -181,7 +181,7 @@ class APIClient:
         resp_dict = xmltodict.parse(resp.content.decode())["Response"]
         success_pattern = "2[0-9][0-9]"
         for key in resp_dict:
-            if "Status" in resp_dict[key]:
+            if "Status" in resp_dict[key] and isinstance(resp_dict[key]["Status"], dict):
                 if not re.search(success_pattern, resp_dict[key]["Status"]["@code"]):
                     raise SophosFirewallAPIError(resp_dict[key])
         return xmltodict.parse(resp.content.decode())
@@ -239,7 +239,7 @@ class APIClient:
         resp_dict = xmltodict.parse(resp.content.decode())["Response"]
         success_pattern = "2[0-9][0-9]"
         for key in resp_dict:
-            if "Status" in resp_dict[key]:
+            if "Status" in resp_dict[key] and isinstance(resp_dict[key]["Status"], dict):
                 if not re.search(success_pattern, resp_dict[key]["Status"]["@code"]):
                     raise SophosFirewallAPIError(resp_dict[key])
         return xmltodict.parse(resp.content.decode())


### PR DESCRIPTION
Describe the bug : - APIClient.submit_xml crashes with a TypeError: string indices must be integers, not 'str' when the Sophos XML API returns a module containing zero records. In these scenarios, the firewall API returns a <Status> tag containing a plain text string instead of a dictionary with a @code attribute, which causes the parser in submit_xml to crash.

To Reproduce Steps to reproduce the behavior:

1. Connect to a Sophos Firewall that has zero SD-WAN policy routes configured.
2. Call the submit_xml function using a module that will return zero records.
    resp = firewall.client.submit_xml("<Get><SDWANPolicyRoute/></Get>", set_operation="")
3.The firewall API returns the following valid XML response
   <SDWANPolicyRoute transactionid="">
      <Status>No. of records Zero.</Status>
  </SDWANPolicyRoute>
4. xmltodict correctly parses this into a Python dictionary where resp_dict["SDWANPolicyRoute"]["Status"] evaluates to the string "No. of records Zero.".
5. The submit_xml function (in api_client.py) blindly attempts to check for a status code using resp_dict[key]["Status"]["@code"], which raises the TypeError because you cannot access dictionary keys on a string.
Expected behavior 

The submit_xml function should safely handle text-only <Status> elements. It should check if resp_dict[key]["Status"] is a dict before attempting to extract the @code attribute, and gracefully return the response data instead of throwing a TypeError.


**Desktop (please complete the following information):**
-OS: Windows
-Python version: 3.x (Insert your specific Python version here, e.g., 3.10)
-Sophos Firewall API Version: 2100.1 (SFOS 21.0.0 GA-Build169)

**Additional context**
The crash specifically occurs in api_client.py around this code block in the submit_xml function:

if "Status" in resp_dict[key]:
    if not re.search(success_pattern, resp_dict[key]["Status"]["@code"]):
        raise SophosFirewallAPIError(resp_dict[key])

A quick fix would be adding a type check to ensure the Status object is actually a dictionary before accessing @code:

if "Status" in resp_dict[key] and isinstance(resp_dict[key]["Status"], dict):

